### PR TITLE
Fixed missing alignment on MinGW + GCC

### DIFF
--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -8,7 +8,7 @@
 #ifndef cglm_types_h
 #define cglm_types_h
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 #  define CGLM_ALIGN(X) /* __declspec(align(X)) */
 #else
 #  define CGLM_ALIGN(X) __attribute((aligned(X)))


### PR DESCRIPTION
MinGW defines _WIN32, so alignment is missing when using GCC.
This patch switches to _MSC_VER, so that GCC is handled properly even on MinGW/Windows