### PR TITLE
new wrappers for lookat

### DIFF
--- a/include/cglm/call/cam.h
+++ b/include/cglm/call/cam.h
@@ -43,10 +43,15 @@ glmc_perspective(float fovy,
 
 CGLM_EXPORT
 void
-glmc_lookat(vec3 eye,
-            vec3 center,
-            vec3 up,
-            mat4 dest);
+glmc_lookat(vec3 eye, vec3 center, vec3 up, mat4 dest);
+
+CGLM_EXPORT
+void
+glmc_look(vec3 eye, vec3 dir, vec3 up, mat4 dest);
+
+CGLM_EXPORT
+void
+glmc_look_any(vec3 eye, vec3 dir, mat4 dest);
 
 CGLM_EXPORT
 void

--- a/include/cglm/call/cam.h
+++ b/include/cglm/call/cam.h
@@ -51,7 +51,7 @@ glmc_look(vec3 eye, vec3 dir, vec3 up, mat4 dest);
 
 CGLM_EXPORT
 void
-glmc_look_any(vec3 eye, vec3 dir, mat4 dest);
+glmc_look_anyup(vec3 eye, vec3 dir, mat4 dest);
 
 CGLM_EXPORT
 void

--- a/include/cglm/cam.h
+++ b/include/cglm/cam.h
@@ -304,6 +304,43 @@ glm_lookat(vec3 eye,
 }
 
 /*!
+ * @brief set up view matrix
+ *
+ * convenient wrapper for lookat: if you only have direction not target self
+ * then this might be useful. Because you need to get target from direction.
+ *
+ * @param[in]  eye    eye vector
+ * @param[in]  dir    direction vector
+ * @param[in]  up     up vector
+ * @param[out] dest   result matrix
+ */
+CGLM_INLINE
+void
+glm_look(vec3 eye, vec3 dir, vec3 up, mat4 dest) {
+  vec3 target;
+  glm_vec_add(eye, dir, target);
+  glm_lookat(eye, target, up, dest);
+}
+
+/*!
+ * @brief set up view matrix
+ *
+ * convenient wrapper for look: if you only have direction and if you don't
+ * care what UP vector is then this might be useful to create view matrix
+ *
+ * @param[in]  eye    eye vector
+ * @param[in]  dir    direction vector
+ * @param[out] dest   result matrix
+ */
+CGLM_INLINE
+void
+glm_look_any(vec3 eye, vec3 dir, mat4 dest) {
+  vec3 up;
+  glm_vec_ortho(dir, up);
+  glm_look(eye, dir, up, dest);
+}
+
+/*!
  * @brief decomposes frustum values of perspective projection.
  *
  * @param[in]  proj    perspective projection matrix

--- a/include/cglm/cam.h
+++ b/include/cglm/cam.h
@@ -334,7 +334,7 @@ glm_look(vec3 eye, vec3 dir, vec3 up, mat4 dest) {
  */
 CGLM_INLINE
 void
-glm_look_any(vec3 eye, vec3 dir, mat4 dest) {
+glm_look_anyup(vec3 eye, vec3 dir, mat4 dest) {
   vec3 up;
   glm_vec_ortho(dir, up);
   glm_look(eye, dir, up, dest);

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -42,6 +42,7 @@
    CGLM_INLINE void  glm_vec_center(vec3 v1, vec3 v2, vec3 dest);
    CGLM_INLINE void  glm_vec_maxv(vec3 v1, vec3 v2, vec3 dest);
    CGLM_INLINE void  glm_vec_minv(vec3 v1, vec3 v2, vec3 dest);
+   CGLM_INLINE void  glm_vec_ortho(vec3 v, vec3 dest);
  */
 
 #ifndef cglm_vec3_h
@@ -454,6 +455,20 @@ glm_vec_minv(vec3 v1, vec3 v2, vec3 dest) {
     dest[2] = v1[2];
   else
     dest[2] = v2[2];
+}
+
+/*!
+ * @brief possible orthogonal/perpendicular vector
+ *
+ * @param[in]  v    vector
+ * @param[out] dest orthogonal/perpendicular vector
+ */
+CGLM_INLINE
+void
+glm_vec_ortho(vec3 v, vec3 dest) {
+  dest[0] = v[1] - v[2];
+  dest[1] = v[2] - v[0];
+  dest[2] = v[0] - v[1];
 }
 
 #endif /* cglm_vec3_h */

--- a/src/cam.c
+++ b/src/cam.c
@@ -69,6 +69,18 @@ glmc_lookat(vec3 eye,
 
 CGLM_EXPORT
 void
+glmc_look(vec3 eye, vec3 dir, vec3 up, mat4 dest) {
+  glm_look(eye, dir, up, dest);
+}
+
+CGLM_EXPORT
+void
+glmc_look_any(vec3 eye, vec3 dir, mat4 dest) {
+  glm_look_any(eye, dir, dest);
+}
+
+CGLM_EXPORT
+void
 glmc_frustum_planes(mat4 m, vec4 dest[6]) {
   glm_frustum_planes(m, dest);
 }

--- a/src/cam.c
+++ b/src/cam.c
@@ -75,8 +75,8 @@ glmc_look(vec3 eye, vec3 dir, vec3 up, mat4 dest) {
 
 CGLM_EXPORT
 void
-glmc_look_any(vec3 eye, vec3 dir, mat4 dest) {
-  glm_look_any(eye, dir, dest);
+glmc_look_anyup(vec3 eye, vec3 dir, mat4 dest) {
+  glm_look_anyup(eye, dir, dest);
 }
 
 CGLM_EXPORT

--- a/test/src/test_cam.c
+++ b/test/src/test_cam.c
@@ -8,6 +8,22 @@
 #include "test_common.h"
 
 void
+test_camera_lookat(void **state) {
+  mat4  view1, view2;
+  vec3 eye    = {0.024f, 14.6f, 67.04f},
+       dir    = {0.0f, 0.0f, -1.0f},
+       up     = GLM_YUP,
+       center;
+
+  glm_vec_add(eye, dir, center);
+  glm_lookat(eye, center, up, view1);
+
+  glm_look(eye, dir, up, view2);
+
+  test_assert_mat4_eq(view1, view2);
+}
+
+void
 test_camera_decomp(void **state) {
   mat4  proj, proj2;
   vec4  sizes;
@@ -35,4 +51,3 @@ test_camera_decomp(void **state) {
 
   test_assert_mat4_eq(proj, proj2);
 }
-

--- a/test/src/test_cam.c
+++ b/test/src/test_cam.c
@@ -10,10 +10,11 @@
 void
 test_camera_lookat(void **state) {
   mat4  view1, view2;
-  vec3 eye    = {0.024f, 14.6f, 67.04f},
+  vec3 center,
+       eye    = {0.024f, 14.6f, 67.04f},
        dir    = {0.0f, 0.0f, -1.0f},
-       up     = GLM_YUP,
-       center;
+       up     = {0.0f, 1.0f, 0.0f}
+  ;
 
   glm_vec_add(eye, dir, center);
   glm_lookat(eye, center, up, view1);

--- a/test/src/test_main.c
+++ b/test/src/test_main.c
@@ -13,10 +13,9 @@ main(int argc, const char * argv[]) {
     cmocka_unit_test(test_mat4),
 
     /* camera */
+    cmocka_unit_test(test_camera_lookat),
     cmocka_unit_test(test_camera_decomp)
   };
 
-  return cmocka_run_group_tests(tests,
-                                NULL,
-                                NULL);
+  return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/src/test_tests.h
+++ b/test/src/test_tests.h
@@ -11,6 +11,9 @@ void test_mat4(void **state);
 
 /* camera */
 void
+test_camera_lookat(void **state);
+
+void
 test_camera_decomp(void **state);
 
 #endif /* test_tests_h */


### PR DESCRIPTION
New vector function:
```C
void glm_vec_ortho(vec3 v, vec3 dest);
```

New camera functions:
```C
void glm_look(vec3 eye, vec3 dir, vec3 up, mat4 dest);
void glm_look_any(vec3 eye, vec3 dir, mat4 dest);
```

Sometimes we have only direction vector to create view matrix. In this case we do this:

```C
vec3 target;
glm_vec_add(eye, dir, target);
glm_lookat(eye, target, up, dest);
```

because we need to target/center to construct view matrix with `lookat`, if we have only direction then target/center we want to create will be fake... 

So let cglm do this for us. `glm_look ` is just wrapper for original `lookat` which accepts `direction` instead of `center/target`. It creates center/target for us.

`glm_vec_ortho` creates possible orthogonal/perpendicular vector for given vector. `look_any` uses this vector as UP vector as orthogonal to direction vector. So if it is not matter what UP vector is, then this makes things easier. 

R