### PR TITLE
vec: convenient wrappers/utils for vectors

### DIFF
--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -20,6 +20,7 @@
    GLM_XUP
 
  Functions:
+   CGLM_INLINE void  glm_vec3(vec4 v4, vec3 dest);
    CGLM_INLINE void  glm_vec_copy(vec3 a, vec3 dest);
    CGLM_INLINE float glm_vec_dot(vec3 a, vec3 b);
    CGLM_INLINE void  glm_vec_cross(vec3 a, vec3 b, vec3 d);
@@ -61,6 +62,20 @@
 #define GLM_YUP  (vec3){0.0f, 1.0f, 0.0f}
 #define GLM_ZUP  (vec3){0.0f, 0.0f, 1.0f}
 #define GLM_XUP  (vec3){1.0f, 0.0f, 0.0f}
+
+/*!
+ * @brief init vec3 using vec4
+ *
+ * @param[in]  v4   vector4
+ * @param[out] dest destination
+ */
+CGLM_INLINE
+void
+glm_vec3(vec4 v4, vec3 dest) {
+  dest[0] = v4[0];
+  dest[1] = v4[1];
+  dest[2] = v4[2];
+}
 
 /*!
  * @brief copy all members of [a] to [dest]
@@ -401,8 +416,8 @@ CGLM_INLINE
 float
 glm_vec_distance(vec3 v1, vec3 v2) {
   return sqrtf(glm_pow2(v2[0] - v1[0])
-               + glm_pow2(v2[1] - v1[1])
-               + glm_pow2(v2[2] - v1[2]));
+             + glm_pow2(v2[1] - v1[1])
+             + glm_pow2(v2[2] - v1[2]));
 }
 
 /*!
@@ -469,6 +484,37 @@ glm_vec_ortho(vec3 v, vec3 dest) {
   dest[0] = v[1] - v[2];
   dest[1] = v[2] - v[0];
   dest[2] = v[0] - v[1];
+}
+
+/*!
+ * @brief vec3 cross product
+ *
+ * this is just convenient wrapper
+ *
+ * @param[in]  a source 1
+ * @param[in]  b source 2
+ * @param[out] d destination
+ */
+CGLM_INLINE
+void
+glm_cross(vec3 a, vec3 b, vec3 d) {
+  glm_vec_cross(a, b, d);
+}
+
+/*!
+ * @brief vec3 dot product
+ *
+ * this is just convenient wrapper
+ *
+ * @param[in] a vector1
+ * @param[in] b vector2
+ *
+ * @return dot product
+ */
+CGLM_INLINE
+float
+glm_dot(vec3 a, vec3 b) {
+  return glm_vec_dot(a, b);
 }
 
 #endif /* cglm_vec3_h */

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -44,6 +44,12 @@
    CGLM_INLINE void  glm_vec_maxv(vec3 v1, vec3 v2, vec3 dest);
    CGLM_INLINE void  glm_vec_minv(vec3 v1, vec3 v2, vec3 dest);
    CGLM_INLINE void  glm_vec_ortho(vec3 v, vec3 dest);
+
+ Convenient:
+   CGLM_INLINE void  glm_cross(vec3 a, vec3 b, vec3 d);
+   CGLM_INLINE float glm_dot(vec3 a, vec3 b);
+   CGLM_INLINE void  glm_normalize(vec3 v);
+   CGLM_INLINE void  glm_normalize_to(vec3 v, vec3 dest);
  */
 
 #ifndef cglm_vec3_h
@@ -515,6 +521,33 @@ CGLM_INLINE
 float
 glm_dot(vec3 a, vec3 b) {
   return glm_vec_dot(a, b);
+}
+
+/*!
+ * @brief normalize vec3 and store result in same vec
+ *
+ * this is just convenient wrapper
+ *
+ * @param[in, out] v vector
+ */
+CGLM_INLINE
+void
+glm_normalize(vec3 v) {
+  glm_vec_normalize(v);
+}
+
+/*!
+ * @brief normalize vec3 to dest
+ *
+ * this is just convenient wrapper
+ *
+ * @param[in]  vec  source
+ * @param[out] dest destination
+ */
+CGLM_INLINE
+void
+glm_normalize_to(vec3 v, vec3 dest) {
+  glm_vec_normalize_to(v, dest);
 }
 
 #endif /* cglm_vec3_h */

--- a/include/cglm/vec4.h
+++ b/include/cglm/vec4.h
@@ -20,6 +20,7 @@
    GLM_VEC4_BLACK
  
  Functions:
+   CGLM_INLINE void  glm_vec4(vec3 v3, float last, vec4 dest);
    CGLM_INLINE void  glm_vec4_copy3(vec4 a, vec3 dest);
    CGLM_INLINE void  glm_vec4_copy(vec4 v, vec4 dest);
    CGLM_INLINE float glm_vec4_dot(vec4 a, vec4 b);
@@ -55,6 +56,22 @@
 
 #define GLM_VEC4_ONE        (vec4)GLM_VEC4_ONE_INIT
 #define GLM_VEC4_BLACK      (vec4)GLM_VEC4_BLACK_INIT
+
+/*!
+ * @brief init vec4 using vec3
+ *
+ * @param[in]  v3   vector3
+ * @param[in]  last last item
+ * @param[out] dest destination
+ */
+CGLM_INLINE
+void
+glm_vec4(vec3 v3, float last, vec4 dest) {
+  dest[0] = v3[0];
+  dest[1] = v3[1];
+  dest[2] = v3[2];
+  dest[3] = last;
+}
 
 /*!
  * @brief copy first 3 members of [a] to [dest]


### PR DESCRIPTION
since **cross** and **dot** is mostly used for vec3 we can promote it to global namespace or with wrappers to original functions.

New functions:
- `glm_cross` convenient wrapper for `glm_vec_cross`
- `glm_dot` convenient  wrapper for `glm_vec_dot`
- `glm_normalize` convenient for `glm_vec_normalize`
- `glm_normalize_to` convenient for `glm_vec_normalize_to`
- `glm_vec3` init vec3 with vec4 (or convert v4 to v3)
- `glm_vec4` init vec4 with vec3 (or convert v3 to v4)

I think these may make codes more readable

Since we use `glm_vec_` namespace for vec3 `glm_vec3()` could be `glm_vec()`but `glm_vec3()` seems more readable to me

In the future we may promote them completely and remove _vec namespace but not sure for that. Just thoughts!