### PR TITLE
bounding box

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -58,3 +58,8 @@ Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix
 Authors:
   Gil Gribb (ggribb@ravensoft.com)
   Klaus Hartmann (k_hartmann@osnabrueck.netsurf.de)
+
+5. Transform AABB
+Transform Axis Aligned Bounding Boxes:
+http://dev.theomader.com/transform-bounding-boxes/
+https://github.com/erich666/GraphicsGems/blob/master/gems/TransBox.c

--- a/LICENSE
+++ b/LICENSE
@@ -63,3 +63,7 @@ Authors:
 Transform Axis Aligned Bounding Boxes:
 http://dev.theomader.com/transform-bounding-boxes/
 https://github.com/erich666/GraphicsGems/blob/master/gems/TransBox.c
+
+6. Cull frustum
+http://www.txutxi.com/?p=584
+http://old.cescg.org/CESCG-2002/DSykoraJJelinek/

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ I realized that floating point errors may occur is some operaitons especially de
 - euler angles / yaw-pitch-roll to matrix
 - extract euler angles
 - inline or pre-compiled function call
-- extract view frustum planes
+- frustum (extract view frustum planes, corners...)
+- bounding box  (AABB in Frustum (culling), crop, merge...)
 
 <hr />
 

--- a/include/cglm/affine.h
+++ b/include/cglm/affine.h
@@ -18,12 +18,12 @@
    CGLM_INLINE void glm_scale(mat4 m, vec3 v);
    CGLM_INLINE void glm_scale1(mat4 m, float s);
    CGLM_INLINE void glm_scale_uni(mat4 m, float s);
-   CGLM_INLINE void glm_rotate_x(mat4 m, float rad, mat4 dest);
-   CGLM_INLINE void glm_rotate_y(mat4 m, float rad, mat4 dest);
-   CGLM_INLINE void glm_rotate_z(mat4 m, float rad, mat4 dest);
+   CGLM_INLINE void glm_rotate_x(mat4 m, float angle, mat4 dest);
+   CGLM_INLINE void glm_rotate_y(mat4 m, float angle, mat4 dest);
+   CGLM_INLINE void glm_rotate_z(mat4 m, float angle, mat4 dest);
    CGLM_INLINE void glm_rotate_ndc_make(mat4 m, float angle, vec3 axis_ndc);
    CGLM_INLINE void glm_rotate_make(mat4 m, float angle, vec3 axis);
-   CGLM_INLINE void glm_rotate_ndc(mat4 m, float angle, vec3 axis_ndc);
+   CGLM_INLINE void glm_rotate_ndc(mat4 m, float angle, vec3 axis);
    CGLM_INLINE void glm_rotate(mat4 m, float angle, vec3 axis);
    CGLM_INLINE void glm_decompose_scalev(mat4 m, vec3 s);
    CGLM_INLINE bool glm_uniscaled(mat4 m);
@@ -122,16 +122,16 @@ glm_translate(mat4 m, vec3 v) {
  */
 CGLM_INLINE
 void
-glm_translate_x(mat4 m, float to) {
+glm_translate_x(mat4 m, float x) {
 #if defined( __SSE__ ) || defined( __SSE2__ )
   _mm_store_ps(m[3],
                _mm_add_ps(_mm_mul_ps(_mm_load_ps(m[0]),
-                                     _mm_set1_ps(to)),
+                                     _mm_set1_ps(x)),
                           _mm_load_ps(m[3])))
   ;
 #else
   vec4 v1;
-  glm_vec4_scale(m[0], to, v1);
+  glm_vec4_scale(m[0], x, v1);
   glm_vec4_add(v1, m[3], m[3]);
 #endif
 }
@@ -144,16 +144,16 @@ glm_translate_x(mat4 m, float to) {
  */
 CGLM_INLINE
 void
-glm_translate_y(mat4 m, float to) {
+glm_translate_y(mat4 m, float y) {
 #if defined( __SSE__ ) || defined( __SSE2__ )
   _mm_store_ps(m[3],
                _mm_add_ps(_mm_mul_ps(_mm_load_ps(m[1]),
-                                     _mm_set1_ps(to)),
+                                     _mm_set1_ps(y)),
                           _mm_load_ps(m[3])))
   ;
 #else
   vec4 v1;
-  glm_vec4_scale(m[1], to, v1);
+  glm_vec4_scale(m[1], y, v1);
   glm_vec4_add(v1, m[3], m[3]);
 #endif
 }
@@ -166,16 +166,16 @@ glm_translate_y(mat4 m, float to) {
  */
 CGLM_INLINE
 void
-glm_translate_z(mat4 m, float to) {
+glm_translate_z(mat4 m, float z) {
 #if defined( __SSE__ ) || defined( __SSE2__ )
   _mm_store_ps(m[3],
                _mm_add_ps(_mm_mul_ps(_mm_load_ps(m[2]),
-                                     _mm_set1_ps(to)),
+                                     _mm_set1_ps(z)),
                           _mm_load_ps(m[3])))
   ;
 #else
   vec4 v1;
-  glm_vec4_scale(m[2], to, v1);
+  glm_vec4_scale(m[2], z, v1);
   glm_vec4_add(v1, m[3], m[3]);
 #endif
 }
@@ -297,13 +297,13 @@ glm_rotate_x(mat4 m, float angle, mat4 dest) {
  */
 CGLM_INLINE
 void
-glm_rotate_y(mat4 m, float rad, mat4 dest) {
+glm_rotate_y(mat4 m, float angle, mat4 dest) {
   float cosVal;
   float sinVal;
   mat4  t = GLM_MAT4_IDENTITY_INIT;
 
-  cosVal = cosf(rad);
-  sinVal = sinf(rad);
+  cosVal = cosf(angle);
+  sinVal = sinf(angle);
 
   t[0][0] =  cosVal;
   t[0][2] = -sinVal;
@@ -323,13 +323,13 @@ glm_rotate_y(mat4 m, float rad, mat4 dest) {
  */
 CGLM_INLINE
 void
-glm_rotate_z(mat4 m, float rad, mat4 dest) {
+glm_rotate_z(mat4 m, float angle, mat4 dest) {
   float cosVal;
   float sinVal;
   mat4  t = GLM_MAT4_IDENTITY_INIT;
 
-  cosVal = cosf(rad);
-  sinVal = sinf(rad);
+  cosVal = cosf(angle);
+  sinVal = sinf(angle);
 
   t[0][0] =  cosVal;
   t[0][1] =  sinVal;
@@ -441,9 +441,9 @@ glm_rotate_ndc(mat4 m, float angle, vec3 axis_ndc) {
 /*!
  * @brief rotate existing transform matrix around Z axis by angle and axis
  *
- * @param[in, out]  m         affine transfrom
- * @param[in]       angle     angle (radians)
- * @param[in]       axis_ndc  axis
+ * @param[in, out]  m      affine transfrom
+ * @param[in]       angle  angle (radians)
+ * @param[in]       axis   axis
  */
 CGLM_INLINE
 void
@@ -457,8 +457,8 @@ glm_rotate(mat4 m, float angle, vec3 axis) {
 /*!
  * @brief decompose scale vector
  *
- * @param[in]  m     affine transform
- * @param[out] s     scale vector (Sx, Sy, Sz)
+ * @param[in]  m  affine transform
+ * @param[out] s  scale vector (Sx, Sy, Sz)
  */
 CGLM_INLINE
 void

--- a/include/cglm/box.h
+++ b/include/cglm/box.h
@@ -120,4 +120,37 @@ glm_aabb_crop_until(vec3 box[2],
   glm_aabb_merge(clampBox, dest, dest);
 }
 
+/*!
+ * @brief check if AABB intersects with frustum planes
+ *
+ * this could be useful for frustum culling using AABB.
+ *
+ * OPTIMIZATION HINT:
+ *  if planes order is similar to LEFT, RIGHT, BOTTOM, TOP, NEAR, FAR
+ *  then this method should run even faster because it would only use two
+ *  planes if object is not inside the two planes
+ *  fortunately cglm extracts planes as this order! just pass what you got!
+ *
+ * @param[in]  box     bounding box
+ * @param[in]  planes  frustum planes
+ */
+CGLM_INLINE
+bool
+glm_aabb_frustum(vec3 *box, vec4 planes[6]) {
+  float *p, dp;
+  int    i;
+
+  for (i = 0; i < 6; i++) {
+    p  = planes[i];
+    dp = p[0] * box[p[0] > 0.0f][0]
+       + p[1] * box[p[1] > 0.0f][1]
+       + p[2] * box[p[2] > 0.0f][2];
+
+    if (dp < -p[3])
+      return false;
+  }
+
+  return true;
+}
+
 #endif /* cglm_box_h */

--- a/include/cglm/box.h
+++ b/include/cglm/box.h
@@ -136,7 +136,7 @@ glm_aabb_crop_until(vec3 box[2],
  */
 CGLM_INLINE
 bool
-glm_aabb_frustum(vec3 *box, vec4 planes[6]) {
+glm_aabb_frustum(vec3 box[2], vec4 planes[6]) {
   float *p, dp;
   int    i;
 

--- a/include/cglm/box.h
+++ b/include/cglm/box.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c), Recep Aslantas.
+ *
+ * MIT License (MIT), http://opensource.org/licenses/MIT
+ * Full license can be found in the LICENSE file
+ */
+
+#ifndef cglm_box_h
+#define cglm_box_h
+
+#include "common.h"
+#include "vec3.h"
+#include "vec4.h"
+
+/*!
+ * @brief apply transform to Axis-Aligned Bounding Box
+ *
+ * @param[in]  box  bounding box
+ * @param[in]  m    transform matrix
+ * @param[out] dest transformed bounding box
+ */
+CGLM_INLINE
+void
+glm_aabb_transform(vec3 box[2], mat4 m, vec3 dest[2]) {
+  vec3 v[2], xa, xb, ya, yb, za, zb, tmp;
+
+  glm_vec_scale(m[0], box[0][0], xa);
+  glm_vec_scale(m[0], box[1][0], xb);
+
+  glm_vec_scale(m[1], box[0][1], ya);
+  glm_vec_scale(m[1], box[1][1], yb);
+
+  glm_vec_scale(m[2], box[0][2], za);
+  glm_vec_scale(m[2], box[1][2], zb);
+
+  /* min(xa, xb) + min(ya, yb) + min(za, zb) + translation */
+  glm_vec_minv(xa, xb, v[0]);
+  glm_vec_minv(ya, yb, tmp);
+  glm_vec_add(v[0], tmp, v[0]);
+  glm_vec_minv(za, zb, tmp);
+  glm_vec_add(v[0], tmp, v[0]);
+  glm_vec_add(v[0], m[3], v[0]);
+
+  /* max(xa, xb) + max(ya, yb) + max(za, zb) + translation */
+  glm_vec_maxv(xa, xb, v[1]);
+  glm_vec_maxv(ya, yb, tmp);
+  glm_vec_add(v[1], tmp, v[1]);
+  glm_vec_maxv(za, zb, tmp);
+  glm_vec_add(v[1], tmp, v[1]);
+  glm_vec_add(v[1], m[3], v[1]);
+
+  glm_vec_copy(v[0], dest[0]);
+  glm_vec_copy(v[1], dest[1]);
+}
+
+/*!
+ * @brief merges two AABB bounding box and creates new one
+ *
+ * two box must be in same space, if one of box is in different space then
+ * you should consider to convert it's space by glm_box_space
+ *
+ * @param[in]  box1 bounding box 1
+ * @param[in]  box2 bounding box 2
+ * @param[out] dest merged bounding box
+ */
+CGLM_INLINE
+void
+glm_aabb_merge(vec3 box1[2], vec3 box2[2], vec3 dest[2]) {
+  dest[0][0] = glm_min(box1[0][0], box2[0][0]);
+  dest[0][1] = glm_min(box1[0][1], box2[0][1]);
+  dest[0][2] = glm_min(box1[0][2], box2[0][2]);
+
+  dest[1][0] = glm_max(box1[1][0], box2[1][0]);
+  dest[1][1] = glm_max(box1[1][1], box2[1][1]);
+  dest[1][2] = glm_max(box1[1][2], box2[1][2]);
+}
+
+/*!
+ * @brief crops a bounding box with another one.
+ *
+ * this could be useful for gettng a bbox which fits with view frustum and
+ * object bounding boxes. In this case you crop view frustum box with objects
+ * box
+ *
+ * @param[in]  box     bounding box 1
+ * @param[in]  cropBox crop box
+ * @param[out] dest    cropped bounding box
+ */
+CGLM_INLINE
+void
+glm_aabb_crop(vec3 box[2], vec3 cropBox[2], vec3 dest[2]) {
+  dest[0][0] = glm_max(box[0][0], cropBox[0][0]);
+  dest[0][1] = glm_max(box[0][1], cropBox[0][1]);
+  dest[0][2] = glm_max(box[0][2], cropBox[0][2]);
+
+  dest[1][0] = glm_min(box[1][0], cropBox[1][0]);
+  dest[1][1] = glm_min(box[1][1], cropBox[1][1]);
+  dest[1][2] = glm_min(box[1][2], cropBox[1][2]);
+}
+
+/*!
+ * @brief crops a bounding box with another one.
+ *
+ * this could be useful for gettng a bbox which fits with view frustum and
+ * object bounding boxes. In this case you crop view frustum box with objects
+ * box
+ *
+ * @param[in]  box      bounding box
+ * @param[in]  cropBox  crop box
+ * @param[in]  clampBox miniumum box
+ * @param[out] dest     cropped bounding box
+ */
+CGLM_INLINE
+void
+glm_aabb_crop_until(vec3 box[2],
+                    vec3 cropBox[2],
+                    vec3 clampBox[2],
+                    vec3 dest[2]) {
+  glm_aabb_crop(box, cropBox, dest);
+  glm_aabb_merge(clampBox, dest, dest);
+}
+
+#endif /* cglm_box_h */

--- a/include/cglm/call.h
+++ b/include/cglm/call.h
@@ -22,6 +22,7 @@ extern "C" {
 #include "call/euler.h"
 #include "call/plane.h"
 #include "call/frustum.h"
+#include "call/box.h"
 #include "call/io.h"
 
 #ifdef __cplusplus

--- a/include/cglm/call/box.h
+++ b/include/cglm/call/box.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c), Recep Aslantas.
+ *
+ * MIT License (MIT), http://opensource.org/licenses/MIT
+ * Full license can be found in the LICENSE file
+ */
+
+#ifndef cglmc_box_h
+#define cglmc_box_h
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "../cglm.h"
+
+CGLM_EXPORT
+void
+glmc_aabb_transform(vec3 box[2], mat4 m, vec3 dest[2]);
+
+CGLM_EXPORT
+void
+glmc_aabb_merge(vec3 box1[2], vec3 box2[2], vec3 dest[2]);
+
+CGLM_EXPORT
+void
+glmc_aabb_crop(vec3 box[2], vec3 cropBox[2], vec3 dest[2]);
+
+CGLM_EXPORT
+void
+glmc_aabb_crop_until(vec3 box[2],
+                     vec3 cropBox[2],
+                     vec3 clampBox[2],
+                     vec3 dest[2]);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* cglmc_box_h */
+

--- a/include/cglm/cam.h
+++ b/include/cglm/cam.h
@@ -52,6 +52,9 @@
    CGLM_INLINE void glm_persp_decomp_near(mat4 proj, float *__restrict nearVal);
    CGLM_INLINE void glm_frustum_planes(mat4 m, vec4 dest[6]);
    CGLM_INLINE void glm_frustum_corners(mat4 invMat, vec4 dest[8]);
+   CGLM_INLINE glm_ortho_box(vec3 box[2], mat4 dest);
+   CGLM_INLINE void glm_ortho_boxp(vec3 box[2], float padding, mat4 dest);
+   CGLM_INLINE void glm_ortho_boxp(vec3 box[2], float padding, mat4 dest);
  */
 
 #ifndef cglm_vcam_h
@@ -133,6 +136,59 @@ glm_ortho(float left,
   dest[3][1] =-(top    + bottom)  * tb;
   dest[3][2] = (farVal + nearVal) * fn;
   dest[3][3] = 1.0f;
+}
+
+/*!
+ * @brief set up orthographic projection matrix using bounding box
+ *
+ * bounding box (AABB) must be in view space
+ *
+ * @param[in]  box   AABB
+ * @param[out] dest  result matrix
+ */
+CGLM_INLINE
+void
+glm_ortho_aabb(vec3 box[2], mat4 dest) {
+  glm_ortho(box[0][0],  box[1][0],
+            box[0][1],  box[1][1],
+           -box[1][2], -box[0][2],
+            dest);
+}
+
+/*!
+ * @brief set up orthographic projection matrix using bounding box
+ *
+ * bounding box (AABB) must be in view space
+ *
+ * @param[in]  box     AABB
+ * @param[in]  padding padding
+ * @param[out] dest    result matrix
+ */
+CGLM_INLINE
+void
+glm_ortho_aabb_p(vec3 box[2], float padding, mat4 dest) {
+  glm_ortho(box[0][0] - padding,    box[1][0] + padding,
+            box[0][1] - padding,    box[1][1] + padding,
+          -(box[1][2] + padding), -(box[0][2] - padding),
+            dest);
+}
+
+/*!
+ * @brief set up orthographic projection matrix using bounding box
+ *
+ * bounding box (AABB) must be in view space
+ *
+ * @param[in]  box     AABB
+ * @param[in]  padding padding for near and far
+ * @param[out] dest    result matrix
+ */
+CGLM_INLINE
+void
+glm_ortho_aabb_pz(vec3 box[2], float padding, mat4 dest) {
+  glm_ortho(box[0][0],              box[1][0],
+            box[0][1],              box[1][1],
+          -(box[1][2] + padding), -(box[0][2] - padding),
+            dest);
 }
 
 /*!

--- a/include/cglm/cglm.h
+++ b/include/cglm/cglm.h
@@ -19,6 +19,7 @@
 #include "quat.h"
 #include "euler.h"
 #include "plane.h"
+#include "box.h"
 #include "util.h"
 #include "io.h"
 

--- a/include/cglm/quat.h
+++ b/include/cglm/quat.h
@@ -126,7 +126,7 @@ glm_quat_norm(versor q) {
 /*!
  * @brief normalize quaternion
  *
- * @param[in, out]  m  quaternion
+ * @param[in, out]  q  quaternion
  */
 CGLM_INLINE
 void
@@ -145,7 +145,7 @@ glm_quat_normalize(versor q) {
 /*!
  * @brief dot product of two quaternion
  *
- * @param[in]  m  quaternion 1
+ * @param[in]  q  quaternion 1
  * @param[in]  r  quaternion 2
  */
 CGLM_INLINE

--- a/include/cglm/util.h
+++ b/include/cglm/util.h
@@ -45,7 +45,7 @@ glm_rad(float deg) {
 /*!
  * @brief convert radians to degree
  *
- * @param[in] deg angle in radians
+ * @param[in] rad angle in radians
  */
 CGLM_INLINE
 float

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -436,20 +436,9 @@ glm_vec_distance(vec3 v1, vec3 v2) {
 CGLM_INLINE
 void
 glm_vec_maxv(vec3 v1, vec3 v2, vec3 dest) {
-  if (v1[0] > v2[0])
-    dest[0] = v1[0];
-  else
-    dest[0] = v2[0];
-
-  if (v1[1] > v2[1])
-    dest[1] = v1[1];
-  else
-    dest[1] = v2[1];
-
-  if (v1[2] > v2[2])
-    dest[2] = v1[2];
-  else
-    dest[2] = v2[2];
+  dest[0] = glm_max(v1[0], v2[0]);
+  dest[1] = glm_max(v1[1], v2[1]);
+  dest[2] = glm_max(v1[2], v2[2]);
 }
 
 /*!
@@ -462,20 +451,9 @@ glm_vec_maxv(vec3 v1, vec3 v2, vec3 dest) {
 CGLM_INLINE
 void
 glm_vec_minv(vec3 v1, vec3 v2, vec3 dest) {
-  if (v1[0] < v2[0])
-    dest[0] = v1[0];
-  else
-    dest[0] = v2[0];
-
-  if (v1[1] < v2[1])
-    dest[1] = v1[1];
-  else
-    dest[1] = v2[1];
-
-  if (v1[2] < v2[2])
-    dest[2] = v1[2];
-  else
-    dest[2] = v2[2];
+  dest[0] = glm_min(v1[0], v2[0]);
+  dest[1] = glm_min(v1[1], v2[1]);
+  dest[2] = glm_min(v1[2], v2[2]);
 }
 
 /*!
@@ -541,7 +519,7 @@ glm_normalize(vec3 v) {
  *
  * this is just convenient wrapper
  *
- * @param[in]  vec  source
+ * @param[in]  v    source
  * @param[out] dest destination
  */
 CGLM_INLINE

--- a/include/cglm/vec4.h
+++ b/include/cglm/vec4.h
@@ -332,9 +332,9 @@ CGLM_INLINE
 float
 glm_vec4_distance(vec4 v1, vec4 v2) {
   return sqrtf(glm_pow2(v2[0] - v1[0])
-               + glm_pow2(v2[1] - v1[1])
-               + glm_pow2(v2[2] - v1[2])
-               + glm_pow2(v2[3] - v1[3]));
+             + glm_pow2(v2[1] - v1[1])
+             + glm_pow2(v2[2] - v1[2])
+             + glm_pow2(v2[3] - v1[3]));
 }
 
 /*!
@@ -347,25 +347,10 @@ glm_vec4_distance(vec4 v1, vec4 v2) {
 CGLM_INLINE
 void
 glm_vec4_maxv(vec4 v1, vec4 v2, vec4 dest) {
-  if (v1[0] > v2[0])
-    dest[0] = v1[0];
-  else
-    dest[0] = v2[0];
-
-  if (v1[1] > v2[1])
-    dest[1] = v1[1];
-  else
-    dest[1] = v2[1];
-
-  if (v1[2] > v2[2])
-    dest[2] = v1[2];
-  else
-    dest[2] = v2[2];
-
-  if (v1[3] > v2[3])
-    dest[3] = v1[3];
-  else
-    dest[3] = v2[3];
+  dest[0] = glm_max(v1[0], v2[0]);
+  dest[1] = glm_max(v1[1], v2[1]);
+  dest[2] = glm_max(v1[2], v2[2]);
+  dest[3] = glm_max(v1[3], v2[3]);
 }
 
 /*!
@@ -378,25 +363,10 @@ glm_vec4_maxv(vec4 v1, vec4 v2, vec4 dest) {
 CGLM_INLINE
 void
 glm_vec4_minv(vec4 v1, vec4 v2, vec4 dest) {
-  if (v1[0] < v2[0])
-    dest[0] = v1[0];
-  else
-    dest[0] = v2[0];
-
-  if (v1[1] < v2[1])
-    dest[1] = v1[1];
-  else
-    dest[1] = v2[1];
-
-  if (v1[2] < v2[2])
-    dest[2] = v1[2];
-  else
-    dest[2] = v2[2];
-
-  if (v1[3] < v2[3])
-    dest[3] = v1[3];
-  else
-    dest[3] = v2[3];
+  dest[0] = glm_min(v1[0], v2[0]);
+  dest[1] = glm_min(v1[1], v2[1]);
+  dest[2] = glm_min(v1[2], v2[2]);
+  dest[3] = glm_min(v1[3], v2[3]);
 }
 
 #endif /* cglm_vec4_h */

--- a/makefile.am
+++ b/makefile.am
@@ -52,7 +52,8 @@ cglm_HEADERS = include/cglm/version.h \
                   include/cglm/quat.h \
                   include/cglm/affine-mat.h \
                   include/cglm/plane.h \
-                  include/cglm/frustum.h
+                  include/cglm/frustum.h \
+                  include/cglm/box.h
 
 cglm_calldir=$(includedir)/cglm/call
 cglm_call_HEADERS = include/cglm/call/mat4.h \
@@ -65,7 +66,8 @@ cglm_call_HEADERS = include/cglm/call/mat4.h \
                     include/cglm/call/quat.h \
                     include/cglm/call/euler.h \
                     include/cglm/call/plane.h \
-                    include/cglm/call/frustum.h
+                    include/cglm/call/frustum.h \
+                    include/cglm/call/box.h
 
 cglm_simddir=$(includedir)/cglm/simd
 cglm_simd_HEADERS = include/cglm/simd/intrin.h
@@ -94,7 +96,8 @@ libcglm_la_SOURCES=\
     src/mat3.c \
     src/mat4.c \
     src/plane.c \
-    src/frustum.c
+    src/frustum.c \
+    src/box.c
 
 test_tests_SOURCES=\
     test/src/test_common.c \

--- a/src/box.c
+++ b/src/box.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c), Recep Aslantas.
+ *
+ * MIT License (MIT), http://opensource.org/licenses/MIT
+ * Full license can be found in the LICENSE file
+ */
+
+#include "../include/cglm/cglm.h"
+#include "../include/cglm/call.h"
+
+CGLM_EXPORT
+void
+glmc_aabb_transform(vec3 box[2], mat4 m, vec3 dest[2]) {
+  glm_aabb_transform(box, m, dest);
+}
+
+CGLM_EXPORT
+void
+glmc_aabb_merge(vec3 box1[2], vec3 box2[2], vec3 dest[2]) {
+  glm_aabb_merge(box1, box2, dest);
+}
+
+CGLM_EXPORT
+void
+glmc_aabb_crop(vec3 box[2], vec3 cropBox[2], vec3 dest[2]) {
+  glm_aabb_crop(box, cropBox, dest);
+}
+
+CGLM_EXPORT
+void
+glmc_aabb_crop_until(vec3 box[2],
+                     vec3 cropBox[2],
+                     vec3 clampBox[2],
+                     vec3 dest[2]) {
+  glm_aabb_crop_until(box, cropBox, clampBox, dest);
+}

--- a/win/cglm.vcxproj
+++ b/win/cglm.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\affine.c" />
+    <ClCompile Include="..\src\box.c" />
     <ClCompile Include="..\src\cam.c" />
     <ClCompile Include="..\src\dllmain.c" />
     <ClCompile Include="..\src\euler.c" />
@@ -35,8 +36,10 @@
   <ItemGroup>
     <ClInclude Include="..\include\cglm\affine-mat.h" />
     <ClInclude Include="..\include\cglm\affine.h" />
+    <ClInclude Include="..\include\cglm\box.h" />
     <ClInclude Include="..\include\cglm\call.h" />
     <ClInclude Include="..\include\cglm\call\affine.h" />
+    <ClInclude Include="..\include\cglm\call\box.h" />
     <ClInclude Include="..\include\cglm\call\cam.h" />
     <ClInclude Include="..\include\cglm\call\euler.h" />
     <ClInclude Include="..\include\cglm\call\frustum.h" />

--- a/win/cglm.vcxproj.filters
+++ b/win/cglm.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="..\src\plane.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\box.c">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\config.h">
@@ -192,6 +195,12 @@
       <Filter>include\cglm</Filter>
     </ClInclude>
     <ClInclude Include="..\include\cglm\plane.h">
+      <Filter>include\cglm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\cglm\call\box.h">
+      <Filter>include\cglm\call</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\cglm\box.h">
       <Filter>include\cglm</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
New functions:
`glm_aabb_transform` - transforms aabb with matrix
`glm_aabb_merge` - merges two axis aligned bounding boxes, creates combined one. 
`glm_aabb_crop` - crop a bbox with another one
`glm_aabb_crop_until`

especially `glm_aabb_crop` is fantastic! e.g. if you have bbox for view frustum and your scene is smaller than view frustum's bbox then you can shrink frustum bbox to scene bbox. If scene bbox is larger than (one edge or all edges) then it picks smaller one. In the end view frustum bbox will be max.

to get scene bbox (pseudo code):
```
sceneBbox = objects[0].bbox
for (i = 1; i < objects->count; i++)
  glm_aabb_merge(sceneBbox, objects[i].bbox, sceneBbox)
```

if you do same for frustum after culled, then you get scene bbox in frustum, scene bbox may larger or may smaller so `glm_aabb_crop` will help to crop it:
```
sceneBbox = frustumObjects[0].bbox
for (i = 1; i < frustumObjects->count; i++)
  glm_aabb_merge(sceneBbox, frustumObjects[i].bbox, sceneBbox)

finalBbox
glm_aabb_crop(frustumBbox, sceneInFrustumBbox, finalBbox)
```

`glm_aabb_transform` is also optimized, I saw it at: http://dev.theomader.com/transform-bounding-boxes/

and implemented in cglm. 

these functions may need more tests and more tests with different cases...

TODOs for future: 
- `glm_aabb_intersects` - check if two bbox intersects or not (boolean)
- `glm_aabb_contains` - check if bbox contains/encloses other bbox or not (boolean)