### PR TITLE
Axis-Aligned Bounding Box (AABB) Extensions

### DIFF
--- a/docs/source/box.rst
+++ b/docs/source/box.rst
@@ -24,6 +24,10 @@ Functions:
 #. :c:func:`glm_aabb_crop`
 #. :c:func:`glm_aabb_crop_until`
 #. :c:func:`glm_aabb_frustum`
+#. :c:func:`glm_aabb_invalidate`
+#. :c:func:`glm_aabb_isvalid`
+#. :c:func:`glm_aabb_size`
+#. :c:func:`glm_aabb_radius`
 
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -91,3 +95,39 @@ Functions documentation
     Parameters:
       | *[in]*   **box**     bounding box
       | *[out]*  **planes**  frustum planes
+
+.. c:function:: void  glm_aabb_invalidate(vec3 box[2])
+
+    | invalidate AABB min and max values
+
+    | It fills *max* values with -FLT_MAX and *min* values with +FLT_MAX
+
+    Parameters:
+      | *[in, out]*   **box**     bounding box
+
+.. c:function:: bool  check if AABB is valid or not
+
+    | check if AABB intersects with frustum planes
+
+    Parameters:
+      | *[in]*   **box**     bounding box
+
+    Returns:
+      returns true if aabb is valid otherwise false
+
+.. c:function:: float  glm_aabb_size(vec3 box[2])
+
+    | distance between of min and max
+
+    Parameters:
+      | *[in]*   **box**     bounding box
+
+    Returns:
+      distance between min - max
+
+.. c:function:: float  glm_aabb_radius(vec3 box[2])
+
+    | radius of sphere which surrounds AABB
+
+    Parameters:
+      | *[in]*   **box**     bounding box

--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -39,6 +39,7 @@ Functions:
 #. :c:func:`glm_vec3_print`
 #. :c:func:`glm_ivec3_print`
 #. :c:func:`glm_versor_print`
+#. :c:func:`glm_aabb_print`
 
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -89,4 +90,13 @@ Functions documentation
 
     Parameters:
       | *[in]*  **vec**      quaternion
+      | *[in]*  **ostream**  FILE to write
+
+.. c:function:: void  glm_aabb_print(versor vec, const char * __restrict tag, FILE * __restrict ostream)
+
+    | print aabb to given stream
+
+    Parameters:
+      | *[in]*  **vec**      aabb (axis-aligned bounding box)
+      | *[in]*  **tag**      tag to find it more easly in logs
       | *[in]*  **ostream**  FILE to write

--- a/include/cglm/box.h
+++ b/include/cglm/box.h
@@ -165,4 +165,16 @@ glm_aabb_invalidate(vec3 box[2]) {
   glm_vec_broadcast(-FLT_MAX, box[1]);
 }
 
+/*!
+ * @brief check if AABB is valid or not
+ *
+ * @param[in]  box bounding box
+ */
+CGLM_INLINE
+bool
+glm_aabb_isvalid(vec3 box[2]) {
+  return glm_vec_max(box[0]) != FLT_MAX
+         && glm_vec_min(box[1]) != -FLT_MAX;
+}
+
 #endif /* cglm_box_h */

--- a/include/cglm/box.h
+++ b/include/cglm/box.h
@@ -177,4 +177,26 @@ glm_aabb_isvalid(vec3 box[2]) {
          && glm_vec_min(box[1]) != -FLT_MAX;
 }
 
+/*!
+ * @brief distance between of min and max
+ *
+ * @param[in]  box bounding box
+ */
+CGLM_INLINE
+float
+glm_aabb_size(vec3 box[2]) {
+  return glm_vec_distance(box[0], box[1]);
+}
+
+/*!
+ * @brief radius of sphere which surrounds AABB
+ *
+ * @param[in]  box bounding box
+ */
+CGLM_INLINE
+float
+glm_aabb_radius(vec3 box[2]) {
+  return glm_aabb_size(box) * 0.5f;
+}
+
 #endif /* cglm_box_h */

--- a/include/cglm/box.h
+++ b/include/cglm/box.h
@@ -153,4 +153,16 @@ glm_aabb_frustum(vec3 box[2], vec4 planes[6]) {
   return true;
 }
 
+/*!
+ * @brief invalidate AABB min and max values
+ *
+ * @param[in, out]  box bounding box
+ */
+CGLM_INLINE
+void
+glm_aabb_invalidate(vec3 box[2]) {
+  glm_vec_broadcast(FLT_MAX,  box[0]);
+  glm_vec_broadcast(-FLT_MAX, box[1]);
+}
+
 #endif /* cglm_box_h */

--- a/include/cglm/io.h
+++ b/include/cglm/io.h
@@ -171,4 +171,33 @@ glm_versor_print(versor vec,
 #undef m
 }
 
+CGLM_INLINE
+void
+glm_aabb_print(vec3                    bbox[2],
+               const char * __restrict tag,
+               FILE       * __restrict ostream) {
+  int i, j;
+
+#define m 3
+
+  fprintf(ostream, "AABB (%s):\n", tag ? tag: "float");
+
+  for (i = 0; i < 2; i++) {
+    fprintf(ostream, "\t|");
+
+    for (j = 0; j < m; j++) {
+      fprintf(ostream, "%0.4f", bbox[i][j]);
+
+      if (j != m - 1)
+        fprintf(ostream, "\t");
+    }
+
+    fprintf(ostream, "|\n");
+  }
+
+  fprintf(ostream, "\n");
+
+#undef m
+}
+
 #endif /* cglm_io_h */


### PR DESCRIPTION
New functions:
- [x] `void glm_aabb_invalidate(vec3 box[2])` - invalidates aabb
- [x] `bool glm_aabb_isvalid(vec3 box[2])` - checks if aabb is invalid
- [x] `void glm_aabb_print(vec3  bbox[2], const char  *tag, FILE *ostream)` - prints aabb
- [x] `float glm_aabb_size(vec3 box[2])` - returns cross size of box
