### PR TITLE
Fix alignment issue when using AVX

### DIFF
--- a/include/cglm/affine-mat.h
+++ b/include/cglm/affine-mat.h
@@ -151,7 +151,7 @@ glm_inv_tr(mat4 mat) {
 #if defined( __SSE__ ) || defined( __SSE2__ )
   glm_inv_tr_sse2(mat);
 #else
-  CGLM_ALIGN(16) mat3 r;
+  CGLM_ALIGN_MAT mat3 r;
   CGLM_ALIGN(16) vec3 t;
 
   /* rotate */

--- a/include/cglm/affine.h
+++ b/include/cglm/affine.h
@@ -244,7 +244,7 @@ glm_scale_uni(mat4 m, float s) {
 CGLM_INLINE
 void
 glm_rotate_x(mat4 m, float angle, mat4 dest) {
-  CGLM_ALIGN(16) mat4 t = GLM_MAT4_IDENTITY_INIT;
+  CGLM_ALIGN_MAT mat4 t = GLM_MAT4_IDENTITY_INIT;
   float c, s;
 
   c = cosf(angle);
@@ -269,7 +269,7 @@ glm_rotate_x(mat4 m, float angle, mat4 dest) {
 CGLM_INLINE
 void
 glm_rotate_y(mat4 m, float angle, mat4 dest) {
-  CGLM_ALIGN(16) mat4 t = GLM_MAT4_IDENTITY_INIT;
+  CGLM_ALIGN_MAT mat4 t = GLM_MAT4_IDENTITY_INIT;
   float c, s;
 
   c = cosf(angle);
@@ -294,7 +294,7 @@ glm_rotate_y(mat4 m, float angle, mat4 dest) {
 CGLM_INLINE
 void
 glm_rotate_z(mat4 m, float angle, mat4 dest) {
-  CGLM_ALIGN(16) mat4 t = GLM_MAT4_IDENTITY_INIT;
+  CGLM_ALIGN_MAT mat4 t = GLM_MAT4_IDENTITY_INIT;
   float c, s;
 
   c = cosf(angle);
@@ -351,7 +351,7 @@ glm_rotate_make(mat4 m, float angle, vec3 axis) {
 CGLM_INLINE
 void
 glm_rotate(mat4 m, float angle, vec3 axis) {
-  CGLM_ALIGN(16) mat4 rot;
+  CGLM_ALIGN_MAT mat4 rot;
   glm_rotate_make(rot, angle, axis);
   glm_mul_rot(m, rot, m);
 }

--- a/include/cglm/mat3.h
+++ b/include/cglm/mat3.h
@@ -81,7 +81,7 @@ glm_mat3_copy(mat3 mat, mat3 dest) {
 CGLM_INLINE
 void
 glm_mat3_identity(mat3 mat) {
-  CGLM_ALIGN(16) mat3 t = GLM_MAT3_IDENTITY_INIT;
+  CGLM_ALIGN_MAT mat3 t = GLM_MAT3_IDENTITY_INIT;
   glm_mat3_copy(t, mat);
 }
 
@@ -155,7 +155,7 @@ glm_mat3_transpose_to(mat3 m, mat3 dest) {
 CGLM_INLINE
 void
 glm_mat3_transpose(mat3 m) {
-  CGLM_ALIGN(16) mat3 tmp;
+  CGLM_ALIGN_MAT mat3 tmp;
 
   tmp[0][1] = m[1][0];
   tmp[0][2] = m[2][0];

--- a/include/cglm/mat4.h
+++ b/include/cglm/mat4.h
@@ -139,7 +139,7 @@ glm_mat4_copy(mat4 mat, mat4 dest) {
 CGLM_INLINE
 void
 glm_mat4_identity(mat4 mat) {
-  CGLM_ALIGN(16) mat4 t = GLM_MAT4_IDENTITY_INIT;
+  mat4 t = GLM_MAT4_IDENTITY_INIT;
   glm_mat4_copy(t, mat);
 }
 

--- a/include/cglm/mat4.h
+++ b/include/cglm/mat4.h
@@ -139,7 +139,7 @@ glm_mat4_copy(mat4 mat, mat4 dest) {
 CGLM_INLINE
 void
 glm_mat4_identity(mat4 mat) {
-  mat4 t = GLM_MAT4_IDENTITY_INIT;
+  CGLM_ALIGN_MAT mat4 t = GLM_MAT4_IDENTITY_INIT;
   glm_mat4_copy(t, mat);
 }
 

--- a/include/cglm/quat.h
+++ b/include/cglm/quat.h
@@ -742,7 +742,7 @@ glm_quat_rotatev(versor q, vec3 v, vec3 dest) {
 CGLM_INLINE
 void
 glm_quat_rotate(mat4 m, versor q, mat4 dest) {
-  CGLM_ALIGN(16) mat4 rot;
+  CGLM_ALIGN_MAT mat4 rot;
   glm_quat_mat4(q, rot);
   glm_mul_rot(m, rot, dest);
 }

--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -26,6 +26,12 @@
 #  define CGLM_ALIGN_IF(X) /* no alignment */
 #endif
 
+#ifdef __AVX__
+#  define CGLM_ALIGN_MAT CGLM_ALIGN(32)
+#else
+#  define CGLM_ALIGN_MAT CGLM_ALIGN(16)
+#endif
+
 typedef float                   vec2[2];
 typedef CGLM_ALIGN_IF(8)  float vec3[3];
 typedef int                    ivec3[3];

--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -31,8 +31,14 @@ typedef CGLM_ALIGN_IF(8)  float vec3[3];
 typedef int                    ivec3[3];
 typedef CGLM_ALIGN_IF(16) float vec4[4];
 
-typedef vec3                    mat3[3];
+#ifdef __AVX__
+typedef CGLM_ALIGN_IF(32) vec3  mat3[3];
+typedef CGLM_ALIGN_IF(32) vec4  mat4[4];
+#else
+typedef                   vec3  mat3[3];
 typedef CGLM_ALIGN_IF(16) vec4  mat4[4];
+#endif
+
 
 typedef vec4                    versor;
 


### PR DESCRIPTION
When AVX is used, the default alignment for `mat3` and `mat4` is still 16 Bytes, which produces a segfault when used, because the `_mm256_load_ps` and `_mm256_store_ps` operations require 32 Byte aligned memory.

This commit fixes this issue by adding a conditional to `types.h` that checks if AVX is used, and if so, aligns `mat3` and `mat4` by 32 Bytes.

It also removes the `CGLM_ALIGN(16)` directive from `glm_mat4_identity` in `mat4.h`, where I encountered this bug, so the default alignment from `types.h` will be used.