### PR TITLE
Replace non-standard M_PI* constants

### DIFF
--- a/include/cglm/cam.h
+++ b/include/cglm/cam.h
@@ -293,7 +293,7 @@ CGLM_INLINE
 void
 glm_perspective_default(float aspect,
                         mat4  dest) {
-  glm_perspective((float)CGLM_PI_4,
+  glm_perspective(GLM_PI_4f,
                   aspect,
                   0.01f,
                   100.0f,

--- a/include/cglm/ease.h
+++ b/include/cglm/ease.h
@@ -19,19 +19,19 @@ glm_ease_linear(float t) {
 CGLM_INLINE
 float
 glm_ease_sine_in(float t) {
-  return sinf((t - 1.0f) * CGLM_PI_2) + 1.0f;
+  return sinf((t - 1.0f) * GLM_PI_2f) + 1.0f;
 }
 
 CGLM_INLINE
 float
 glm_ease_sine_out(float t) {
-  return sinf(t * CGLM_PI_2);
+  return sinf(t * GLM_PI_2f);
 }
 
 CGLM_INLINE
 float
 glm_ease_sine_inout(float t) {
-  return 0.5f * (1.0f - cosf(t * CGLM_PI));
+  return 0.5f * (1.0f - cosf(t * GLM_PIf));
 }
 
 CGLM_INLINE
@@ -254,13 +254,13 @@ glm_ease_back_inout(float t) {
 CGLM_INLINE
 float
 glm_ease_elast_in(float t) {
-  return sinf(13.0f * CGLM_PI_2 * t) * powf(2.0f, 10.0f * (t - 1.0f));
+  return sinf(13.0f * GLM_PI_2f * t) * powf(2.0f, 10.0f * (t - 1.0f));
 }
 
 CGLM_INLINE
 float
 glm_ease_elast_out(float t) {
-  return sinf(-13.0f * CGLM_PI_2 * (t + 1.0f)) * powf(2.0f, -10.0f * t) + 1.0f;
+  return sinf(-13.0f * GLM_PI_2f * (t + 1.0f)) * powf(2.0f, -10.0f * t) + 1.0f;
 }
 
 CGLM_INLINE
@@ -271,10 +271,10 @@ glm_ease_elast_inout(float t) {
   a = 2.0f * t;
 
   if (t < 0.5f)
-    return 0.5f * sinf(13.0f * CGLM_PI_2 * a)
+    return 0.5f * sinf(13.0f * GLM_PI_2f * a)
                 * powf(2.0f, 10.0f * (a - 1.0f));
 
-  return 0.5f * (sinf(-13.0f * CGLM_PI_2 * a)
+  return 0.5f * (sinf(-13.0f * GLM_PI_2f * a)
                  * powf(2.0f, -10.0f * (a - 1.0f)) + 2.0f);
 }
 

--- a/include/cglm/euler.h
+++ b/include/cglm/euler.h
@@ -84,12 +84,12 @@ glm_euler_angles(mat4 m, vec3 dest) {
       thetaZ = atan2f(-m10, m00);
     } else { /* m20 == -1 */
       /* Not a unique solution */
-      thetaY = -CGLM_PI_2;
+      thetaY = -GLM_PI_2f;
       thetaX = -atan2f(m01, m11);
       thetaZ =  0.0f;
     }
   } else { /* m20 == +1 */
-    thetaY = CGLM_PI_2;
+    thetaY = GLM_PI_2f;
     thetaX = atan2f(m01, m11);
     thetaZ = 0.0f;
   }

--- a/include/cglm/quat.h
+++ b/include/cglm/quat.h
@@ -689,7 +689,7 @@ glm_quat_for(vec3 dir, vec3 fwd, vec3 up, versor dest) {
 
   dot = glm_vec_dot(dir, fwd);
   if (fabsf(dot + 1.0f)  < 0.000001f) {
-    glm_quat_init(dest, up[0], up[1], up[2], CGLM_PI);
+    glm_quat_init(dest, up[0], up[1], up[2], GLM_PIf);
     return;
   }
 

--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -48,8 +48,17 @@ typedef CGLM_ALIGN_IF(16) vec4  mat4[4];
 
 typedef vec4                    versor;
 
-#define CGLM_PI    ((float)3.14159265358979323846264338327950288)
-#define CGLM_PI_2  ((float)1.57079632679489661923132169163975144)
-#define CGLM_PI_4  ((float)0.785398163397448309615660845819875721)
+#define GLM_PI     3.14159265358979323846264338327950288
+#define GLM_PI_2   1.57079632679489661923132169163975144
+#define GLM_PI_4   0.785398163397448309615660845819875721
+
+#define GLM_PIf    ((float)GLM_PI)
+#define GLM_PI_2f  ((float)GLM_PI_2)
+#define GLM_PI_4f  ((float)GLM_PI_4)
+
+/* DEPRECATED! use GLM_PI and friends */
+#define CGLM_PI    GLM_PIf
+#define CGLM_PI_2  GLM_PI_2f
+#define CGLM_PI_4  GLM_PI_4f
 
 #endif /* cglm_types_h */

--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -48,8 +48,8 @@ typedef CGLM_ALIGN_IF(16) vec4  mat4[4];
 
 typedef vec4                    versor;
 
-#define CGLM_PI    ((float)3.14159265358979323846)
-#define CGLM_PI_2  ((float)1.57079632679489661923)
-#define CGLM_PI_4  ((float)0.78539816339744830962)
+#define CGLM_PI    ((float)3.14159265358979323846264338327950288)
+#define CGLM_PI_2  ((float)1.57079632679489661923132169163975144)
+#define CGLM_PI_4  ((float)0.785398163397448309615660845819875721)
 
 #endif /* cglm_types_h */

--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -45,7 +45,6 @@ typedef                   vec3  mat3[3];
 typedef CGLM_ALIGN_IF(16) vec4  mat4[4];
 #endif
 
-
 typedef vec4                    versor;
 
 #define GLM_E         2.71828182845904523536028747135266250   /* e              */
@@ -62,23 +61,23 @@ typedef vec4                    versor;
 #define GLM_SQRT2     1.41421356237309504880168872420969808   /* sqrt(2)        */
 #define GLM_SQRT1_2   0.707106781186547524400844362104849039  /* 1/sqrt(2)      */
 
-#define GLM_Ef        ((float) GLM_E)
-#define GLM_LOG2Ef    ((float) GLM_LOG2E)
-#define GLM_LOG10Ef   ((float) GLM_LOG10E)
-#define GLM_LN2f      ((float) GLM_LN2)
-#define GLM_LN10f     ((float) GLM_LN10)
-#define GLM_PIf       ((float) GLM_PI)
-#define GLM_PI_2f     ((float) GLM_PI_2)
-#define GLM_PI_4f     ((float) GLM_PI_4)
-#define GLM_1_PIf     ((float) GLM_1_PI)
-#define GLM_2_PIf     ((float) GLM_2_PI)
-#define GLM_2_SQRTPIf ((float) GLM_2_SQRTPI)
-#define GLM_SQRT2f    ((float) GLM_SQRT2)
-#define GLM_SQRT1_2f  ((float) GLM_SQRT1_2)
+#define GLM_Ef        ((float)GLM_E)
+#define GLM_LOG2Ef    ((float)GLM_LOG2E)
+#define GLM_LOG10Ef   ((float)GLM_LOG10E)
+#define GLM_LN2f      ((float)GLM_LN2)
+#define GLM_LN10f     ((float)GLM_LN10)
+#define GLM_PIf       ((float)GLM_PI)
+#define GLM_PI_2f     ((float)GLM_PI_2)
+#define GLM_PI_4f     ((float)GLM_PI_4)
+#define GLM_1_PIf     ((float)GLM_1_PI)
+#define GLM_2_PIf     ((float)GLM_2_PI)
+#define GLM_2_SQRTPIf ((float)GLM_2_SQRTPI)
+#define GLM_SQRT2f    ((float)GLM_SQRT2)
+#define GLM_SQRT1_2f  ((float)GLM_SQRT1_2)
 
 /* DEPRECATED! use GLM_PI and friends */
-#define CGLM_PI    GLM_PIf
-#define CGLM_PI_2  GLM_PI_2f
-#define CGLM_PI_4  GLM_PI_4f
+#define CGLM_PI       GLM_PIf
+#define CGLM_PI_2     GLM_PI_2f
+#define CGLM_PI_4     GLM_PI_4f
 
 #endif /* cglm_types_h */

--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -48,13 +48,33 @@ typedef CGLM_ALIGN_IF(16) vec4  mat4[4];
 
 typedef vec4                    versor;
 
-#define GLM_PI     3.14159265358979323846264338327950288
-#define GLM_PI_2   1.57079632679489661923132169163975144
-#define GLM_PI_4   0.785398163397448309615660845819875721
+#define GLM_E         2.71828182845904523536028747135266250   /* e              */
+#define GLM_LOG2E     1.44269504088896340735992468100189214   /* log2(e)        */
+#define GLM_LOG10E    0.434294481903251827651128918916605082  /* log10(e)       */
+#define GLM_LN2       0.693147180559945309417232121458176568  /* loge(2)        */
+#define GLM_LN10      2.30258509299404568401799145468436421   /* loge(10)       */
+#define GLM_PI        3.14159265358979323846264338327950288   /* pi             */
+#define GLM_PI_2      1.57079632679489661923132169163975144   /* pi/2           */
+#define GLM_PI_4      0.785398163397448309615660845819875721  /* pi/4           */
+#define GLM_1_PI      0.318309886183790671537767526745028724  /* 1/pi           */
+#define GLM_2_PI      0.636619772367581343075535053490057448  /* 2/pi           */
+#define GLM_2_SQRTPI  1.12837916709551257389615890312154517   /* 2/sqrt(pi)     */
+#define GLM_SQRT2     1.41421356237309504880168872420969808   /* sqrt(2)        */
+#define GLM_SQRT1_2   0.707106781186547524400844362104849039  /* 1/sqrt(2)      */
 
-#define GLM_PIf    ((float)GLM_PI)
-#define GLM_PI_2f  ((float)GLM_PI_2)
-#define GLM_PI_4f  ((float)GLM_PI_4)
+#define GLM_Ef        ((float) GLM_E)
+#define GLM_LOG2Ef    ((float) GLM_LOG2E)
+#define GLM_LOG10Ef   ((float) GLM_LOG10E)
+#define GLM_LN2f      ((float) GLM_LN2)
+#define GLM_LN10f     ((float) GLM_LN10)
+#define GLM_PIf       ((float) GLM_PI)
+#define GLM_PI_2f     ((float) GLM_PI_2)
+#define GLM_PI_4f     ((float) GLM_PI_4)
+#define GLM_1_PIf     ((float) GLM_1_PI)
+#define GLM_2_PIf     ((float) GLM_2_PI)
+#define GLM_2_SQRTPIf ((float) GLM_2_SQRTPI)
+#define GLM_SQRT2f    ((float) GLM_SQRT2)
+#define GLM_SQRT1_2f  ((float) GLM_SQRT1_2)
 
 /* DEPRECATED! use GLM_PI and friends */
 #define CGLM_PI    GLM_PIf

--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -48,8 +48,8 @@ typedef CGLM_ALIGN_IF(16) vec4  mat4[4];
 
 typedef vec4                    versor;
 
-#define CGLM_PI    ((float)M_PI)
-#define CGLM_PI_2  ((float)M_PI_2)
-#define CGLM_PI_4  ((float)M_PI_4)
+#define CGLM_PI    ((float)3.14159265358979323846)
+#define CGLM_PI_2  ((float)1.57079632679489661923)
+#define CGLM_PI_4  ((float)0.78539816339744830962)
 
 #endif /* cglm_types_h */

--- a/include/cglm/util.h
+++ b/include/cglm/util.h
@@ -58,7 +58,7 @@ glm_signf(float val) {
 CGLM_INLINE
 float
 glm_rad(float deg) {
-  return deg * CGLM_PI / 180.0f;
+  return deg * GLM_PIf / 180.0f;
 }
 
 /*!
@@ -69,7 +69,7 @@ glm_rad(float deg) {
 CGLM_INLINE
 float
 glm_deg(float rad) {
-  return rad * 180.0f / CGLM_PI;
+  return rad * 180.0f / GLM_PIf;
 }
 
 /*!
@@ -80,7 +80,7 @@ glm_deg(float rad) {
 CGLM_INLINE
 void
 glm_make_rad(float *deg) {
-  *deg = *deg * CGLM_PI / 180.0f;
+  *deg = *deg * GLM_PIf / 180.0f;
 }
 
 /*!
@@ -91,7 +91,7 @@ glm_make_rad(float *deg) {
 CGLM_INLINE
 void
 glm_make_deg(float *rad) {
-  *rad = *rad * 180.0f / CGLM_PI;
+  *rad = *rad * 180.0f / GLM_PIf;
 }
 
 /*!

--- a/test/src/test_affine.c
+++ b/test/src/test_affine.c
@@ -12,7 +12,7 @@ test_affine(void **state) {
   mat4 t1, t2, t3, t4, t5;
 
   /* test translate is postmultiplied */
-  glmc_rotate_make(t1, M_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t1, t2, t3); /* R * T */
@@ -21,16 +21,16 @@ test_affine(void **state) {
   test_assert_mat4_eq(t1, t3);
 
   /* test rotate is postmultiplied */
-  glmc_rotate_make(t1, M_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
 
-  glm_rotate(t2, M_PI_4, GLM_YUP);
+  glm_rotate(t2, CGLM_PI_4, GLM_YUP);
   test_assert_mat4_eq(t2, t3);
 
   /* test scale is postmultiplied */
-  glmc_rotate_make(t1, M_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 57, 36});
   glm_scale_make(t4, (vec3){3, 5, 6});
 
@@ -41,7 +41,7 @@ test_affine(void **state) {
   test_assert_mat4_eq(t3, t5);
 
   /* test translate_x */
-  glmc_rotate_make(t1, M_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 0, 0});
 
   glmc_mat4_mul(t1, t2, t3); /* R * T */
@@ -49,7 +49,7 @@ test_affine(void **state) {
   test_assert_mat4_eq(t1, t3);
 
   /* test translate_y */
-  glmc_rotate_make(t1, M_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
   glm_translate_make(t2, (vec3){0, 57, 0});
 
   glmc_mat4_mul(t1, t2, t3); /* R * T */
@@ -57,7 +57,7 @@ test_affine(void **state) {
   test_assert_mat4_eq(t1, t3);
 
   /* test translate_z */
-  glmc_rotate_make(t1, M_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
   glm_translate_make(t2, (vec3){0, 0, 36});
 
   glmc_mat4_mul(t1, t2, t3); /* R * T */
@@ -65,43 +65,43 @@ test_affine(void **state) {
   test_assert_mat4_eq(t1, t3);
 
   /* test rotate_x */
-  glmc_rotate_make(t1, M_PI_4, (vec3){1, 0, 0});
+  glmc_rotate_make(t1, CGLM_PI_4, (vec3){1, 0, 0});
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
 
-  glm_rotate_x(t2, M_PI_4, t2);
+  glm_rotate_x(t2, CGLM_PI_4, t2);
   test_assert_mat4_eq(t2, t3);
 
   /* test rotate_y */
-  glmc_rotate_make(t1, M_PI_4, (vec3){0, 1, 0});
+  glmc_rotate_make(t1, CGLM_PI_4, (vec3){0, 1, 0});
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
 
-  glm_rotate_y(t2, M_PI_4, t2);
+  glm_rotate_y(t2, CGLM_PI_4, t2);
   test_assert_mat4_eq(t2, t3);
 
   /* test rotate_z */
-  glmc_rotate_make(t1, M_PI_4, (vec3){0, 0, 1});
+  glmc_rotate_make(t1, CGLM_PI_4, (vec3){0, 0, 1});
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
 
-  glm_rotate_z(t2, M_PI_4, t2);
+  glm_rotate_z(t2, CGLM_PI_4, t2);
   test_assert_mat4_eq(t2, t3);
 
   /* test rotate */
-  glmc_rotate_make(t1, M_PI_4, (vec3){0, 0, 1});
+  glmc_rotate_make(t1, CGLM_PI_4, (vec3){0, 0, 1});
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
-  glmc_rotate(t2, M_PI_4, (vec3){0, 0, 1});
+  glmc_rotate(t2, CGLM_PI_4, (vec3){0, 0, 1});
 
   test_assert_mat4_eq(t3, t2);
 
   /* test scale_uni */
-  glmc_rotate_make(t1, M_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 57, 36});
   glm_scale_make(t4, (vec3){3, 3, 3});
 

--- a/test/src/test_affine.c
+++ b/test/src/test_affine.c
@@ -12,7 +12,7 @@ test_affine(void **state) {
   mat4 t1, t2, t3, t4, t5;
 
   /* test translate is postmultiplied */
-  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, GLM_PI_4f, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t1, t2, t3); /* R * T */
@@ -21,16 +21,16 @@ test_affine(void **state) {
   test_assert_mat4_eq(t1, t3);
 
   /* test rotate is postmultiplied */
-  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, GLM_PI_4f, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
 
-  glm_rotate(t2, CGLM_PI_4, GLM_YUP);
+  glm_rotate(t2, GLM_PI_4f, GLM_YUP);
   test_assert_mat4_eq(t2, t3);
 
   /* test scale is postmultiplied */
-  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, GLM_PI_4f, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 57, 36});
   glm_scale_make(t4, (vec3){3, 5, 6});
 
@@ -41,7 +41,7 @@ test_affine(void **state) {
   test_assert_mat4_eq(t3, t5);
 
   /* test translate_x */
-  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, GLM_PI_4f, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 0, 0});
 
   glmc_mat4_mul(t1, t2, t3); /* R * T */
@@ -49,7 +49,7 @@ test_affine(void **state) {
   test_assert_mat4_eq(t1, t3);
 
   /* test translate_y */
-  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, GLM_PI_4f, GLM_YUP);
   glm_translate_make(t2, (vec3){0, 57, 0});
 
   glmc_mat4_mul(t1, t2, t3); /* R * T */
@@ -57,7 +57,7 @@ test_affine(void **state) {
   test_assert_mat4_eq(t1, t3);
 
   /* test translate_z */
-  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, GLM_PI_4f, GLM_YUP);
   glm_translate_make(t2, (vec3){0, 0, 36});
 
   glmc_mat4_mul(t1, t2, t3); /* R * T */
@@ -65,43 +65,43 @@ test_affine(void **state) {
   test_assert_mat4_eq(t1, t3);
 
   /* test rotate_x */
-  glmc_rotate_make(t1, CGLM_PI_4, (vec3){1, 0, 0});
+  glmc_rotate_make(t1, GLM_PI_4f, (vec3){1, 0, 0});
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
 
-  glm_rotate_x(t2, CGLM_PI_4, t2);
+  glm_rotate_x(t2, GLM_PI_4f, t2);
   test_assert_mat4_eq(t2, t3);
 
   /* test rotate_y */
-  glmc_rotate_make(t1, CGLM_PI_4, (vec3){0, 1, 0});
+  glmc_rotate_make(t1, GLM_PI_4f, (vec3){0, 1, 0});
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
 
-  glm_rotate_y(t2, CGLM_PI_4, t2);
+  glm_rotate_y(t2, GLM_PI_4f, t2);
   test_assert_mat4_eq(t2, t3);
 
   /* test rotate_z */
-  glmc_rotate_make(t1, CGLM_PI_4, (vec3){0, 0, 1});
+  glmc_rotate_make(t1, GLM_PI_4f, (vec3){0, 0, 1});
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
 
-  glm_rotate_z(t2, CGLM_PI_4, t2);
+  glm_rotate_z(t2, GLM_PI_4f, t2);
   test_assert_mat4_eq(t2, t3);
 
   /* test rotate */
-  glmc_rotate_make(t1, CGLM_PI_4, (vec3){0, 0, 1});
+  glmc_rotate_make(t1, GLM_PI_4f, (vec3){0, 0, 1});
   glm_translate_make(t2, (vec3){34, 57, 36});
 
   glmc_mat4_mul(t2, t1, t3); /* T * R */
-  glmc_rotate(t2, CGLM_PI_4, (vec3){0, 0, 1});
+  glmc_rotate(t2, GLM_PI_4f, (vec3){0, 0, 1});
 
   test_assert_mat4_eq(t3, t2);
 
   /* test scale_uni */
-  glmc_rotate_make(t1, CGLM_PI_4, GLM_YUP);
+  glmc_rotate_make(t1, GLM_PI_4f, GLM_YUP);
   glm_translate_make(t2, (vec3){34, 57, 36});
   glm_scale_make(t4, (vec3){3, 3, 3});
 


### PR DESCRIPTION
The constants `M_PI`, `M_PI_2` and `M_PI_4` are not in the C standard. If you, for example, run GCC in strict C99 mode, including CGLM headers will fail to compile.

A minimal example to demonstrate, let's call it `mpi.c`:

```c
#include <cglm/cglm.h>
int main(void) {       
    return 0;
}
```

Trying to compile this with `gcc -std=c99 mpi.c` will barf saying that `M_PI` isn't defined.

```
$ gcc -std=c99 mpi.c
In file included from /usr/local/include/cglm/common.h:57:0,
                 from /usr/local/include/cglm/cglm.h:11,
                 from mpi.c:1:
/usr/local/include/cglm/util.h: In function ‘glm_rad’:
/usr/local/include/cglm/util.h:61:16: error: ‘M_PI’ undeclared (first use in this function); did you mean ‘__P’?
   return deg * CGLM_PI / 180.0f;

(And like a dozen more errors like this.)
```

This pull request simply replaces those constants with their literal numeric values. I retained the cast from double to float to make sure there's really no change in behavior.

For comparison, the definitions in [musl libc](https://github.com/cloudius-systems/musl/blob/00733dd1cf791d13ff6155509cf139a5f7b2eecb/include/math.h#L363-L365) and [glibc](https://github.com/lattera/glibc/blob/master/math/math.h#L1065-L1067) are identical.