### PR TITLE
vector update

### DIFF
--- a/docs/source/vec3.rst
+++ b/docs/source/vec3.rst
@@ -52,6 +52,8 @@ Functions:
 #. :c:func:`glm_vec_muladds`
 #. :c:func:`glm_vec_flipsign`
 #. :c:func:`glm_vec_flipsign_to`
+#. :c:func:`glm_vec_negate`
+#. :c:func:`glm_vec_negate_to`
 #. :c:func:`glm_vec_inv`
 #. :c:func:`glm_vec_inv_to`
 #. :c:func:`glm_vec_normalize`
@@ -276,6 +278,21 @@ Functions documentation
 .. c:function:: void  glm_vec_flipsign_to(vec3 v, vec3 dest)
 
     flip sign of all vec3 members and store result in dest
+
+    Parameters:
+      | *[in]*  **v**       vector
+      | *[out]* **dest**    negated vector
+
+.. c:function:: void  glm_vec_negate(vec3 v)
+
+    negate vector components
+
+    Parameters:
+      | *[in, out]*  **v**    vector
+
+.. c:function:: void  glm_vec_negate_to(vec3 v, vec3 dest)
+
+    negate vector components and store result in dest
 
     Parameters:
       | *[in]*  **v**       vector

--- a/include/cglm/affine-mat.h
+++ b/include/cglm/affine-mat.h
@@ -160,7 +160,7 @@ glm_inv_tr(mat4 mat) {
 
   /* translate */
   glm_mat3_mulv(r, mat[3], t);
-  glm_vec_flipsign(t);
+  glm_vec_negate(t);
   glm_vec_copy(t, mat[3]);
 #endif
 }

--- a/include/cglm/affine.h
+++ b/include/cglm/affine.h
@@ -370,7 +370,7 @@ void
 glm_rotate_at(mat4 m, vec3 pivot, float angle, vec3 axis) {
   CGLM_ALIGN(8) vec3 pivotInv;
 
-  glm_vec_inv_to(pivot, pivotInv);
+  glm_vec_negate_to(pivot, pivotInv);
 
   glm_translate(m, pivot);
   glm_rotate(m, angle, axis);
@@ -395,7 +395,7 @@ void
 glm_rotate_atm(mat4 m, vec3 pivot, float angle, vec3 axis) {
   CGLM_ALIGN(8) vec3 pivotInv;
 
-  glm_vec_inv_to(pivot, pivotInv);
+  glm_vec_negate_to(pivot, pivotInv);
 
   glm_translate_make(m, pivot);
   glm_rotate(m, angle, axis);
@@ -467,7 +467,7 @@ glm_decompose_rs(mat4 m, mat4 r, vec3 s) {
     glm_vec4_flipsign(r[0]);
     glm_vec4_flipsign(r[1]);
     glm_vec4_flipsign(r[2]);
-    glm_vec_flipsign(s);
+    glm_vec_negate(s);
   }
 }
 

--- a/include/cglm/call/vec3.h
+++ b/include/cglm/call/vec3.h
@@ -118,6 +118,14 @@ glmc_vec_flipsign_to(vec3 v, vec3 dest);
 
 CGLM_EXPORT
 void
+glmc_vec_negate(vec3 v);
+
+CGLM_EXPORT
+void
+glmc_vec_negate_to(vec3 v, vec3 dest);
+
+CGLM_EXPORT
+void
 glmc_vec_inv(vec3 v);
 
 CGLM_EXPORT

--- a/include/cglm/quat.h
+++ b/include/cglm/quat.h
@@ -670,7 +670,7 @@ glm_quat_look(vec3 eye, versor ori, mat4 dest) {
 
   /* translate */
   glm_mat4_mulv3(dest, eye, 1.0f, dest[3]);
-  glm_vec_flipsign(dest[3]);
+  glm_vec_negate(dest[3]);
 }
 
 /*!
@@ -778,7 +778,7 @@ void
 glm_quat_rotate_at(mat4 m, versor q, vec3 pivot) {
   CGLM_ALIGN(8) vec3 pivotInv;
 
-  glm_vec_inv_to(pivot, pivotInv);
+  glm_vec_negate_to(pivot, pivotInv);
 
   glm_translate(m, pivot);
   glm_quat_rotate(m, q, m);
@@ -802,7 +802,7 @@ void
 glm_quat_rotate_atm(mat4 m, versor q, vec3 pivot) {
   CGLM_ALIGN(8) vec3 pivotInv;
 
-  glm_vec_inv_to(pivot, pivotInv);
+  glm_vec_negate_to(pivot, pivotInv);
 
   glm_translate_make(m, pivot);
   glm_quat_rotate(m, q, m);

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -548,11 +548,18 @@ glm_vec_normalize_to(vec3 vec, vec3 dest) {
 CGLM_INLINE
 float
 glm_vec_angle(vec3 v1, vec3 v2) {
-  float norm;
+  float norm, dot;
 
   /* maybe compiler generate approximation instruction (rcp) */
   norm = 1.0f / (glm_vec_norm(v1) * glm_vec_norm(v2));
-  return acosf(glm_vec_dot(v1, v2) * norm);
+  dot  = glm_vec_dot(v1, v2) * norm;
+
+  if (dot > 1.0f)
+    return 0.0f;
+  else if (dot < -1.0f)
+    return CGLM_PI;
+
+  return acosf(dot);
 }
 
 /*!

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -481,7 +481,7 @@ glm_vec_negate(vec3 v) {
 CGLM_INLINE
 void
 glm_vec_inv(vec3 v) {
-  glm_vec_flipsign(v);
+  glm_vec_negate(v);
 }
 
 /*!
@@ -493,7 +493,7 @@ glm_vec_inv(vec3 v) {
 CGLM_INLINE
 void
 glm_vec_inv_to(vec3 v, vec3 dest) {
-  glm_vec_flipsign_to(v, dest);
+  glm_vec_negate_to(v, dest);
 }
 
 /*!

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -24,6 +24,8 @@
  Functions:
    CGLM_INLINE void  glm_vec3(vec4 v4, vec3 dest);
    CGLM_INLINE void  glm_vec_copy(vec3 a, vec3 dest);
+   CGLM_INLINE void  glm_vec_zero(vec3 v);
+   CGLM_INLINE void  glm_vec_one(vec3 v);
    CGLM_INLINE float glm_vec_dot(vec3 a, vec3 b);
    CGLM_INLINE void  glm_vec_cross(vec3 a, vec3 b, vec3 d);
    CGLM_INLINE float glm_vec_norm2(vec3 v);
@@ -40,7 +42,11 @@
    CGLM_INLINE void  glm_vec_addadd(vec3 a, vec3 b, vec3 dest);
    CGLM_INLINE void  glm_vec_subadd(vec3 a, vec3 b, vec3 dest);
    CGLM_INLINE void  glm_vec_muladd(vec3 a, vec3 b, vec3 dest);
+   CGLM_INLINE void  glm_vec_muladds(vec3 a, float s, vec3 dest);
    CGLM_INLINE void  glm_vec_flipsign(vec3 v);
+   CGLM_INLINE void  glm_vec_flipsign_to(vec3 v, vec3 dest);
+   CGLM_INLINE void  glm_vec_negate_to(vec3 v, vec3 dest);
+   CGLM_INLINE void  glm_vec_negate(vec3 v);
    CGLM_INLINE void  glm_vec_inv(vec3 v);
    CGLM_INLINE void  glm_vec_inv_to(vec3 v, vec3 dest);
    CGLM_INLINE void  glm_vec_normalize(vec3 v);
@@ -49,18 +55,26 @@
    CGLM_INLINE float glm_vec_angle(vec3 v1, vec3 v2);
    CGLM_INLINE void  glm_vec_rotate(vec3 v, float angle, vec3 axis);
    CGLM_INLINE void  glm_vec_rotate_m4(mat4 m, vec3 v, vec3 dest);
+   CGLM_INLINE void  glm_vec_rotate_m4(mat3 m, vec3 v, vec3 dest);
    CGLM_INLINE void  glm_vec_proj(vec3 a, vec3 b, vec3 dest);
    CGLM_INLINE void  glm_vec_center(vec3 v1, vec3 v2, vec3 dest);
+   CGLM_INLINE float glm_vec_distance2(vec3 v1, vec3 v2);
    CGLM_INLINE void  glm_vec_maxv(vec3 v1, vec3 v2, vec3 dest);
    CGLM_INLINE void  glm_vec_minv(vec3 v1, vec3 v2, vec3 dest);
    CGLM_INLINE void  glm_vec_ortho(vec3 v, vec3 dest);
    CGLM_INLINE void  glm_vec_clamp(vec3 v, float minVal, float maxVal);
+   CGLM_INLINE void  glm_vec_lerp(vec3 from, vec3 to, float t, vec3 dest);
 
  Convenient:
    CGLM_INLINE void  glm_cross(vec3 a, vec3 b, vec3 d);
    CGLM_INLINE float glm_dot(vec3 a, vec3 b);
    CGLM_INLINE void  glm_normalize(vec3 v);
    CGLM_INLINE void  glm_normalize_to(vec3 v, vec3 dest);
+
+ DEPRECATED:
+   glm_vec_dup
+   glm_vec_flipsign
+   glm_vec_flipsign_to
  */
 
 #ifndef cglm_vec3_h
@@ -120,9 +134,7 @@ glm_vec_copy(vec3 a, vec3 dest) {
 CGLM_INLINE
 void
 glm_vec_zero(vec3 v) {
-  v[0] = 0.0f;
-  v[1] = 0.0f;
-  v[2] = 0.0f;
+  v[0] = v[1] = v[2] = 0.0f;
 }
 
 /*!
@@ -133,9 +145,7 @@ glm_vec_zero(vec3 v) {
 CGLM_INLINE
 void
 glm_vec_one(vec3 v) {
-  v[0] = 1.0f;
-  v[1] = 1.0f;
-  v[2] = 1.0f;
+  v[0] = v[1] = v[2] = 1.0f;
 }
 
 /*!
@@ -408,7 +418,9 @@ glm_vec_muladds(vec3 a, float s, vec3 dest) {
 }
 
 /*!
- * @brief flip sign of all vec3 members
+ * DEPRECATED! use glm_vec_negate and friends
+ *
+ * @brief negate vector components
  *
  * @param[in, out]  v  vector
  */
@@ -421,7 +433,9 @@ glm_vec_flipsign(vec3 v) {
 }
 
 /*!
- * @brief flip sign of all vec3 members and store result in dest
+ * DEPRECATED! use glm_vec_negate and friends
+ *
+ * @brief negate vector components and store result in dest
  *
  * @param[in]   v     vector
  * @param[out]  dest  result vector
@@ -432,6 +446,31 @@ glm_vec_flipsign_to(vec3 v, vec3 dest) {
   dest[0] = -v[0];
   dest[1] = -v[1];
   dest[2] = -v[2];
+}
+
+/*!
+ * @brief negate vector components and store result in dest
+ *
+ * @param[in]   v     vector
+ * @param[out]  dest  result vector
+ */
+CGLM_INLINE
+void
+glm_vec_negate_to(vec3 v, vec3 dest) {
+  dest[0] = -v[0];
+  dest[1] = -v[1];
+  dest[2] = -v[2];
+}
+
+/*!
+ * @brief negate vector components
+ *
+ * @param[in, out]  v  vector
+ */
+CGLM_INLINE
+void
+glm_vec_negate(vec3 v) {
+  glm_vec_negate_to(v, v);
 }
 
 /*!

--- a/src/vec3.c
+++ b/src/vec3.c
@@ -160,6 +160,18 @@ glmc_vec_flipsign_to(vec3 v, vec3 dest) {
 
 CGLM_EXPORT
 void
+glmc_vec_negate(vec3 v) {
+  glm_vec_negate(v);
+}
+
+CGLM_EXPORT
+void
+glmc_vec_negate_to(vec3 v, vec3 dest) {
+  glm_vec_negate_to(v, dest);
+}
+
+CGLM_EXPORT
+void
 glmc_vec_inv(vec3 v) {
   glm_vec_inv(v);
 }


### PR DESCRIPTION
I have just realized that `glm_vec_angle()` sometimes returns **NaN**,  because `acosf()` returns **NaN** if `cosine < -1.0 or cosine > 1.0`. Now it is more stable, it checks the range:

We can define helpers like `glm_acosf()` to make this more generic?

Old Version:
```C
return acosf(dot);
```

New version:
```C
if (dot > 1.0f)
  return 0.0f;
else if (dot < -1.0f)
  return CGLM_PI;

return acosf(dot);
```

Possible changes:
- [x] bufix/improve: fix `glm_vec_angle()` if cosine/dot is out of range
- [x] new function `glm_vec_negate() ` to deprecate `glm_vec_flipsign()`, it does same thing but with better name
- [ ] rename glm_vec_ namespace to glm_vec3_?
- [ ] `glm_vec_inv()` inverts sign of components (same as negate) but probably it should invert vector components like glMatrix.js (https://github.com/toji/gl-matrix/blob/master/src/vec3.js#L321)?
- [ ] **vec2** functions like `glm_vec2_**` (similar issues: https://github.com/recp/cglm/issues/67 https://github.com/recp/cglm/issues/66)