### PR TITLE
Resolve vec4 : glm_vec4_distance() to satisfy compiling on armv7

### DIFF
--- a/include/cglm/vec4.h
+++ b/include/cglm/vec4.h
@@ -690,12 +690,7 @@ CGLM_INLINE
 float
 glm_vec4_distance(vec4 a, vec4 b) {
 #if defined( __SSE__ ) || defined( __SSE2__ )
-  __m128 x0;
-  x0 = _mm_sub_ps(glmm_load(b), glmm_load(a));
-  x0 = _mm_mul_ps(x0, x0);
-  x0 = _mm_add_ps(x0, glmm_shuff1(x0, 1, 0, 3, 2));
-  return _mm_cvtss_f32(_mm_sqrt_ss(_mm_add_ss(x0,
-                                              glmm_shuff1(x0, 0, 1, 0, 1))));
+  return glmm_norm(_mm_sub_ps(glmm_load(b), glmm_load(a)));
 #elif defined(CGLM_NEON_FP)
   return glmm_norm(vsubq_f32(glmm_load(a), glmm_load(b)));
 #else

--- a/include/cglm/vec4.h
+++ b/include/cglm/vec4.h
@@ -697,11 +697,7 @@ glm_vec4_distance(vec4 a, vec4 b) {
   return _mm_cvtss_f32(_mm_sqrt_ss(_mm_add_ss(x0,
                                               glmm_shuff1(x0, 0, 1, 0, 1))));
 #elif defined(CGLM_NEON_FP)
-  float32x4_t v0;
-  float32_t   r;
-  v0 = vsubq_f32(vld1q_f32(a), vld1q_f32(b));
-  r  = vaddvq_f32(vmulq_f32(v0, v0));
-  return sqrtf(r);
+  return glmm_norm(vsubq_f32(glmm_load(a), glmm_load(b)));
 #else
   return sqrtf(glm_pow2(b[0] - a[0])
              + glm_pow2(b[1] - a[1])

--- a/test/src/test_common.c
+++ b/test/src/test_common.c
@@ -5,6 +5,7 @@
 
 #include "test_common.h"
 #include <stdlib.h>
+#include <math.h>
 
 #define m 4
 #define n 4

--- a/test/src/test_vec4.c
+++ b/test/src/test_vec4.c
@@ -93,6 +93,13 @@ test_vec4(void **state) {
     /* 3. test SIMD norm2 */
     test_rand_vec4(v);
     test_assert_eqf(test_vec4_norm2(v), glm_vec4_norm2(v));
+
+    /* 4. test SSE/SIMD distance */
+    test_rand_vec4(v1);
+    test_rand_vec4(v2);
+    d1 = glm_vec4_distance(v1, v2);
+    d2 = sqrtf(powf(v1[0]-v2[0], 2.0f) + pow(v1[1]-v2[1], 2.0f) + pow(v1[2]-v2[2], 2.0f) + pow(v1[3]-v2[3], 2.0f));
+    assert_true(fabsf(d1 - d2) <= 0.000009);
   }
 
   /* test zero */


### PR DESCRIPTION
Fixed according to @recp 's suggestion of solution at #82 .
Test cases are added.

Tested on PC (Linux ubuntu 18.04 with SSE/SSE2/SSE3/SSE4 capable).
Tested on real Android device (Android 6.0, aarch64).