### PR TITLE
Make Building With Prefix Work

### DIFF
--- a/makefile.am
+++ b/makefile.am
@@ -132,5 +132,11 @@ test_tests_SOURCES=\
     test/src/test_affine.c \
     test/src/test_bezier.c
 
+# When running configure with --prefix, $VPATH references
+# the source directory that post-build.sh is in. When not
+# using a prefix, $VPATH will be unset, so we need to fall
+# back to using . to run the script.
+export VPATH
+
 all-local:
-	sh ./post-build.sh
+	sh $${VPATH:-.}/post-build.sh


### PR DESCRIPTION
Context: I'm using a configure prefix to build native and emscripten versions of this library in different directories. In that case, the current directory will be the build directory, not the source directory.

Steps to reproduce:

* Create a directory and cd into it.
* `/path/to/cglm/configure --prefix="$(pwd)"`
* `make`

Without this patch, it'll try to run `./post-build.sh`, which fails cause it's not in `.`.

With this patch, it'll run `/path/to/cglm/post-build.sh` instead, which is the right thing to do.