### PR TITLE
Helpers for apple's simd library

### DIFF
--- a/include/cglm/applesimd.h
+++ b/include/cglm/applesimd.h
@@ -43,5 +43,37 @@ glm_mat4_applesimd(mat4 m) {
   return t;
 }
 
+CGLM_INLINE
+simd_float3x3
+glm_mat3_applesimd(mat3 m) {
+  simd_float3x3 t;
+  
+  t.columns[0][0] = m[0][0];
+  t.columns[0][1] = m[0][1];
+  t.columns[0][2] = m[0][2];
+
+  t.columns[1][0] = m[1][0];
+  t.columns[1][1] = m[1][1];
+  t.columns[1][2] = m[1][2];
+
+  t.columns[2][0] = m[2][0];
+  t.columns[2][1] = m[2][1];
+  t.columns[2][2] = m[2][2];
+
+  return t;
+}
+
+CGLM_INLINE
+simd_float4
+glm_vec4_applesimd(vec4 v) {
+  return (simd_float4){v[0], v[1], v[2], v[3]};
+}
+
+CGLM_INLINE
+simd_float3
+glm_vec3_applesimd(vec3 v) {
+  return (simd_float3){v[0], v[1], v[2]};
+}
+
 #endif
 #endif /* cglm_applesimd_h */

--- a/include/cglm/applesimd.h
+++ b/include/cglm/applesimd.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c), Recep Aslantas.
+ *
+ * MIT License (MIT), http://opensource.org/licenses/MIT
+ * Full license can be found in the LICENSE file
+ */
+
+#ifndef cglm_applesimd_h
+#define cglm_applesimd_h
+#if defined(__APPLE__)                                                        \
+    && defined(SIMD_COMPILER_HAS_REQUIRED_FEATURES)                           \
+    && defined(SIMD_BASE)                                                     \
+    && defined(SIMD_TYPES)                                                    \
+    && defined(SIMD_VECTOR_TYPES)
+
+#include "common.h"
+
+CGLM_INLINE
+simd_float4x4
+glm_mat4_applesimd(mat4 m) {
+  simd_float4x4 t;
+  
+  t.columns[0][0] = m[0][0];
+  t.columns[0][1] = m[0][1];
+  t.columns[0][2] = m[0][2];
+  t.columns[0][3] = m[0][3];
+
+  t.columns[1][0] = m[1][0];
+  t.columns[1][1] = m[1][1];
+  t.columns[1][2] = m[1][2];
+  t.columns[1][3] = m[1][3];
+
+  t.columns[2][0] = m[2][0];
+  t.columns[2][1] = m[2][1];
+  t.columns[2][2] = m[2][2];
+  t.columns[2][3] = m[2][3];
+
+  t.columns[3][0] = m[3][0];
+  t.columns[3][1] = m[3][1];
+  t.columns[3][2] = m[3][2];
+  t.columns[3][3] = m[3][3];
+
+  return t;
+}
+
+#endif
+#endif /* cglm_applesimd_h */

--- a/include/cglm/mat4.h
+++ b/include/cglm/mat4.h
@@ -723,4 +723,36 @@ glm_mat4_rmc(vec4 r, mat4 m, vec4 c) {
   return glm_vec4_dot(r, tmp);
 }
 
+#if defined(__APPLE__)                                                        \
+    && defined(SIMD_BASE)                                                     \
+    && defined(SIMD_COMPILER_HAS_REQUIRED_FEATURES)                           \
+    && defined(SIMD_VECTOR_TYPES)
+simd_float4x4
+glm_mat4_applesimd(mat4 m) {
+  simd_float4x4 t;
+  
+  t.columns[0][0] = m[0][0];
+  t.columns[0][0] = m[0][1];
+  t.columns[0][0] = m[0][2];
+  t.columns[0][0] = m[0][3];
+  
+  t.columns[1][0] = m[1][0];
+  t.columns[1][1] = m[1][1];
+  t.columns[1][2] = m[1][2];
+  t.columns[1][3] = m[1][3];
+  
+  t.columns[2][0] = m[2][0];
+  t.columns[2][1] = m[2][1];
+  t.columns[2][2] = m[2][2];
+  t.columns[2][3] = m[2][3];
+  
+  t.columns[3][0] = m[3][0];
+  t.columns[3][1] = m[3][1];
+  t.columns[3][2] = m[3][2];
+  t.columns[3][3] = m[3][3];
+  
+  return t;
+}
+#endif
+
 #endif /* cglm_mat_h */

--- a/include/cglm/mat4.h
+++ b/include/cglm/mat4.h
@@ -723,38 +723,4 @@ glm_mat4_rmc(vec4 r, mat4 m, vec4 c) {
   return glm_vec4_dot(r, tmp);
 }
 
-#if defined(__APPLE__)                                                        \
-    && defined(SIMD_COMPILER_HAS_REQUIRED_FEATURES)                           \
-    && defined(SIMD_BASE)                                                     \
-    && defined(SIMD_TYPES)                                                    \
-    && defined(SIMD_VECTOR_TYPES)
-CGLM_INLINE
-simd_float4x4
-glm_mat4_applesimd(mat4 m) {
-  simd_float4x4 t;
-  
-  t.columns[0][0] = m[0][0];
-  t.columns[0][1] = m[0][1];
-  t.columns[0][2] = m[0][2];
-  t.columns[0][3] = m[0][3];
-
-  t.columns[1][0] = m[1][0];
-  t.columns[1][1] = m[1][1];
-  t.columns[1][2] = m[1][2];
-  t.columns[1][3] = m[1][3];
-
-  t.columns[2][0] = m[2][0];
-  t.columns[2][1] = m[2][1];
-  t.columns[2][2] = m[2][2];
-  t.columns[2][3] = m[2][3];
-
-  t.columns[3][0] = m[3][0];
-  t.columns[3][1] = m[3][1];
-  t.columns[3][2] = m[3][2];
-  t.columns[3][3] = m[3][3];
-
-  return t;
-}
-#endif
-
 #endif /* cglm_mat_h */

--- a/include/cglm/mat4.h
+++ b/include/cglm/mat4.h
@@ -724,33 +724,35 @@ glm_mat4_rmc(vec4 r, mat4 m, vec4 c) {
 }
 
 #if defined(__APPLE__)                                                        \
-    && defined(SIMD_BASE)                                                     \
     && defined(SIMD_COMPILER_HAS_REQUIRED_FEATURES)                           \
+    && defined(SIMD_BASE)                                                     \
+    && defined(SIMD_TYPES)                                                    \
     && defined(SIMD_VECTOR_TYPES)
+CGLM_INLINE
 simd_float4x4
 glm_mat4_applesimd(mat4 m) {
   simd_float4x4 t;
   
   t.columns[0][0] = m[0][0];
-  t.columns[0][0] = m[0][1];
-  t.columns[0][0] = m[0][2];
-  t.columns[0][0] = m[0][3];
-  
+  t.columns[0][1] = m[0][1];
+  t.columns[0][2] = m[0][2];
+  t.columns[0][3] = m[0][3];
+
   t.columns[1][0] = m[1][0];
   t.columns[1][1] = m[1][1];
   t.columns[1][2] = m[1][2];
   t.columns[1][3] = m[1][3];
-  
+
   t.columns[2][0] = m[2][0];
   t.columns[2][1] = m[2][1];
   t.columns[2][2] = m[2][2];
   t.columns[2][3] = m[2][3];
-  
+
   t.columns[3][0] = m[3][0];
   t.columns[3][1] = m[3][1];
   t.columns[3][2] = m[3][2];
   t.columns[3][3] = m[3][3];
-  
+
   return t;
 }
 #endif


### PR DESCRIPTION
This PR provides some helpers to convert **cglm**'s types to apple's simd library to make it easy to use **cglm** with Apple's **Metal / MetalGL** api:

- mat4 to simd_float4x4
- mat3 to simd_float3x3
- vec4 to simd_float4
- vec3 to simd_float3

Example:

Apple's example:

```Obj-C
- (void)mtkView:(nonnull MTKView *)view drawableSizeWillChange:(CGSize)size
   float aspect = size.width / (float)size.height;
   _projectionMatrix = matrix_perspective_right_hand(65.0f * (M_PI / 180.0f), aspect, 0.1f, 100.0f);
}

matrix_float4x4 matrix_perspective_right_hand(float fovyRadians, float aspect, float nearZ, float farZ)
{
    float ys = 1 / tanf(fovyRadians * 0.5);
    float xs = ys / aspect;
    float zs = farZ / (nearZ - farZ);

    return (matrix_float4x4) {{
        { xs,   0,          0,  0 },
        {  0,  ys,          0,  0 },
        {  0,   0,         zs, -1 },
        {  0,   0, nearZ * zs,  0 }
    }};
}
```

Can be written like this:

```Obj-C
- (void)mtkView:(nonnull MTKView *)view drawableSizeWillChange:(CGSize)size
  mat4 proj;

  float aspect = size.width / (float)size.height;
  
  glm_perspective(glm_rad(65.0f), aspect, 0.1f, 100.0f, proj);

  /* convert cglm's type to apple's simd type */  
  _projectionMatrix = glm_mat4_applesimd(proj);
}
```

feedbacks are welcome! Rejecting this PR is also an option. 

PS: this checks existence of <simd/simd.h> by checking header guards