### PR TITLE
Change `()` Prototypes to `(void)`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,8 @@ AM_CFLAGS = -Wall \
             -O3 \
             -Wstrict-aliasing=2 \
             -fstrict-aliasing \
-            -pedantic
+            -pedantic \
+            -Werror=strict-prototypes
 
 lib_LTLIBRARIES = libcglm.la
 libcglm_la_LDFLAGS = -no-undefined -version-info 0:1:0

--- a/include/cglm/struct/mat3.h
+++ b/include/cglm/struct/mat3.h
@@ -14,9 +14,9 @@
 
  Functions:
    CGLM_INLINE mat3s  glms_mat3_copy(mat3s mat);
-   CGLM_INLINE mat3s  glms_mat3_identity();
+   CGLM_INLINE mat3s  glms_mat3_identity(void);
    CGLM_INLINE void   glms_mat3_identity_array(mat3s * __restrict mat, size_t count);
-   CGLM_INLINE mat3s  glms_mat3_zero();
+   CGLM_INLINE mat3s  glms_mat3_zero(void);
    CGLM_INLINE mat3s  glms_mat3_mul(mat3s m1, mat3s m2);
    CGLM_INLINE ma3s   glms_mat3_transpose(mat3s m);
    CGLM_INLINE vec3s  glms_mat3_mulv(mat3s m, vec3s v);
@@ -79,7 +79,7 @@ glms_mat3_copy(mat3s mat) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_identity() {
+glms_mat3_identity(void) {
   mat3s r;
   glm_mat3_identity(r.raw);
   return r;
@@ -111,7 +111,7 @@ glms_mat3_identity_array(mat3s * __restrict mat, size_t count) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_zero() {
+glms_mat3_zero(void) {
   mat3s r;
   glm_mat3_zero(r.raw);
   return r;

--- a/include/cglm/struct/mat4.h
+++ b/include/cglm/struct/mat4.h
@@ -20,9 +20,9 @@
  Functions:
    CGLM_INLINE mat4s   glms_mat4_ucopy(mat4s mat);
    CGLM_INLINE mat4s   glms_mat4_copy(mat4s mat);
-   CGLM_INLINE mat4s   glms_mat4_identity();
+   CGLM_INLINE mat4s   glms_mat4_identity(void);
    CGLM_INLINE void    glms_mat4_identity_array(mat4s * __restrict mat, size_t count);
-   CGLM_INLINE mat4s   glms_mat4_zero();
+   CGLM_INLINE mat4s   glms_mat4_zero(void);
    CGLM_INLINE mat3s   glms_mat4_pick3(mat4s mat);
    CGLM_INLINE mat3s   glms_mat4_pick3t(mat4s mat);
    CGLM_INLINE mat4s   glms_mat4_ins3(mat3s mat);
@@ -114,7 +114,7 @@ glms_mat4_copy(mat4s mat) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_identity() {
+glms_mat4_identity(void) {
   mat4s r;
   glm_mat4_identity(r.raw);
   return r;
@@ -146,7 +146,7 @@ glms_mat4_identity_array(mat4s * __restrict mat, size_t count) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_zero() {
+glms_mat4_zero(void) {
   mat4s r;
   glm_mat4_zero(r.raw);
   return r;

--- a/include/cglm/struct/quat.h
+++ b/include/cglm/struct/quat.h
@@ -11,7 +11,7 @@
    GLMS_QUAT_IDENTITY
 
  Functions:
-   CGLM_INLINE versors glms_quat_identity()
+   CGLM_INLINE versors glms_quat_identity(void)
    CGLM_INLINE void    glms_quat_identity_array(versor *q, size_t count)
    CGLM_INLINE versors glms_quat_init(float x, float y, float z, float w)
    CGLM_INLINE versors glms_quatv(float angle, vec3s axis)
@@ -72,7 +72,7 @@
  */
 CGLM_INLINE
 versors
-glms_quat_identity() {
+glms_quat_identity(void) {
   versors dest;
   glm_quat_identity(dest.raw);
   return dest;

--- a/include/cglm/struct/vec3.h
+++ b/include/cglm/struct/vec3.h
@@ -19,8 +19,8 @@
    CGLM_INLINE vec3s glms_vec3(vec4s v4);
    CGLM_INLINE void  glms_vec3_pack(vec3s dst[], vec3 src[], size_t len);
    CGLM_INLINE void  glms_vec3_unpack(vec3 dst[], vec3s src[], size_t len);
-   CGLM_INLINE vec3s glms_vec3_zero();
-   CGLM_INLINE vec3s glms_vec3_one();
+   CGLM_INLINE vec3s glms_vec3_zero(void);
+   CGLM_INLINE vec3s glms_vec3_one(void);
    CGLM_INLINE float glms_vec3_dot(vec3s a, vec3s b);
    CGLM_INLINE float glms_vec3_norm2(vec3s v);
    CGLM_INLINE float glms_vec3_norm(vec3s v);
@@ -151,7 +151,7 @@ glms_vec3_unpack(vec3 dst[], vec3s src[], size_t len) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_zero() {
+glms_vec3_zero(void) {
   vec3s r;
   glm_vec3_zero(r.raw);
   return r;
@@ -164,7 +164,7 @@ glms_vec3_zero() {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_one() {
+glms_vec3_one(void) {
   vec3s r;
   glm_vec3_one(r.raw);
   return r;

--- a/include/cglm/struct/vec4.h
+++ b/include/cglm/struct/vec4.h
@@ -180,7 +180,7 @@ glms_vec4_unpack(vec4 dst[], vec4s src[], size_t len) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_zero() {
+glms_vec4_zero(void) {
   vec4s r;
   glm_vec4_zero(r.raw);
   return r;
@@ -193,7 +193,7 @@ glms_vec4_zero() {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_one() {
+glms_vec4_one(void) {
   vec4s r;
   glm_vec4_one(r.raw);
   return r;


### PR DESCRIPTION
There's a few functions that have an empty prototype `()`, which should be `(void)` instead. This patch fixes that.

Since it's nonsense to have an empty prototype, I've added `-Werror=strict-prototypes` to the build options. This will throw a compile error in these cases so they can be avoided ahead of time.