### PR TITLE
Add a vec2s struct type for consistency

### DIFF
--- a/include/cglm/types-struct.h
+++ b/include/cglm/types-struct.h
@@ -10,6 +10,16 @@
 
 #include "types.h"
 
+typedef union vec2s {
+#ifndef CGLM_NO_ANONYMOUS_STRUCT
+  struct {
+    float x;
+    float y;
+  };
+#endif
+  vec2 raw;
+} vec2s;
+
 typedef union vec3s {
 #ifndef CGLM_NO_ANONYMOUS_STRUCT
   struct {


### PR DESCRIPTION
There's a vec2 type, so there should probably be a struct version of it too. Even if no functions use it right now, if a library user (like me) needs a 2-element vector, they don't need to roll their own.

Presumably there _will_ be uses for vec2s, so I don't think it hurts to add it now. It wouldn't cause issues for me if it didn't though, it just means I have to keep using my own struct for now.