### PR TITLE
Fix small documentation mistake

### DIFF
--- a/docs/source/cam.rst
+++ b/docs/source/cam.rst
@@ -198,7 +198,7 @@ Functions documentation
 
     Parameters:
       | *[in]*  **eye**     eye vector
-      | *[in]*  **center**  direction vector
+      | *[in]*  **dir**     direction vector
       | *[in]*  **up**      up vector
       | *[out]* **dest**    result matrix
 
@@ -212,7 +212,7 @@ Functions documentation
 
     Parameters:
       | *[in]*  **eye**     eye vector
-      | *[in]*  **center**  direction vector
+      | *[in]*  **dir**     direction vector
       | *[out]* **dest**    result matrix
 
 .. c:function:: void  glm_persp_decomp(mat4 proj, float *nearVal, float *farVal, float *top, float *bottom, float *left, float *right)


### PR DESCRIPTION
I think I noticed a small mistake in the documentation: At two points in the documentation the names of the parameters in the parameters list do not match the parameter names in the function:
- `glm_look`
- `glm_look_anyup`

Namely the parameter `center` which should I think should be `dir`.