### PR TITLE
Fix documentation mistake for `glm_vec3_rotate`

### DIFF
--- a/docs/source/vec3.rst
+++ b/docs/source/vec3.rst
@@ -392,7 +392,7 @@ Functions documentation
     Parameters:
       | *[in, out]*  **v**      vector
       | *[in]*       **axis**   axis vector (will be normalized)
-      | *[out]*      **angle**  angle (radians)
+      | *[in]*       **angle**  angle (radians)
 
 .. c:function:: void  glm_vec3_rotate_m4(mat4 m, vec3 v, vec3 dest)
 


### PR DESCRIPTION
I think I found another small mistake in the documentation; This, for `glm_vec3_rotate`, correctly labels `angle` as `in` rather than `out`.