### PR TITLE
Make Github recognize header language as C

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.h linguist-language=C


### PR DESCRIPTION
On the homepage of the repository, there is a color-coded indicator for which languages are used. It seems this repository contains a lot of C# and C++, because Github marks a lot of `*.h` files as C++ or Objective-C. I haven't gone through all of them to check, but I suppose all `*.h` files in this repo are actually C?

Adding this file should fix this, I think, according to [this documentation](https://github.com/github/linguist#using-gitattributes). I can't say this with 100% certainty, as Github's indexing is somewhat limited on forked repos (and I'm of course working in a fork) so I can't test it, but it seems to me this should be the correct fix.