### PR TITLE
use Ken Shoemake's algorithm (gemsiv/euler_angle)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -65,3 +65,19 @@ https://forums.khronos.org/showthread.php/10651-Animation-TCB-Spline-Interpolati
 12. vec2 cross product
 http://allenchou.net/2013/07/cross-product-of-2d-vectors/
 
+13. Ken Shoemake's algorithm Implementation and Euler
+Ken Shoemake's algorithm impl. is taken from this repo by permission:
+  https://github.com/erich666/GraphicsGems/blob/master/gemsiv/euler_angle
+
+* -------------------------- GraphicsGems EULA ----------------------------- *
+|   http://www.realtimerendering.com/resources/GraphicsGems/                 |
+|                                                                            |
+| EULA: The Graphics Gems code is copyright-protected. In other words, you   |
+| cannot claim the text of the code as your own and resell it. Using the     |
+| code is permitted in any program, product, or library, non-commercial or   |
+| commercial. Giving credit is not required, though is a nice gesture.       |
+| The code comes as-is, and if there are any flaws or problems with any Gems |
+| code, nobody involved with Gems - authors, editors, publishers, or         |
+| webmasters - are to be held responsible. Basically, don't be a jerk, and   |
+| remember that anything free comes with no guarantee.                       |
+* -------------------------------- END --------------------------------------*/

--- a/include/cglm/euler.h
+++ b/include/cglm/euler.h
@@ -38,7 +38,7 @@
  | Related issue: https://github.com/recp/cglm/issues/30                      |
  |                                                                            |
  * -------------------------- GraphicsGems EULA ----------------------------- *
- | Related EULA for GraphicsGems can be found at and below, plus in CREDITS:  |
+ | Related EULA for GraphicsGems can be found at below, plus in CREDITS:      |
  |   http://www.realtimerendering.com/resources/GraphicsGems/                 |
  |                                                                            |
  | EULA: The Graphics Gems code is copyright-protected. In other words, you   |

--- a/include/cglm/euler.h
+++ b/include/cglm/euler.h
@@ -34,7 +34,6 @@
  | cglm doesn't claim the ownership of GraphicsGems source codes              |
  | and the algorithm itself. But cglm may change variable names or some piece |
  | of codes in order to apply optimizations or to make it usable in cglm.     |
- | The ownership of improvements                                              |
  |                                                                            |
  | Related issue: https://github.com/recp/cglm/issues/30                      |
  |                                                                            |


### PR DESCRIPTION
Ken Shoemake's algorithm seems to be most common one, it also handles 24 different permutations of rotation order. This must be more robust and flexible api.

I was sent an email to @erich666 (~2018 I guess) to get permission to include GraphicsGems's euler code in this repo (with a few modifications) by giving a reference to original source code. 

I added this to tope of `cglm/euler.h` header:

```C
/* ---------- Notice for Ken Shoemake's algorithm Implementation -------------*
 | Ken Shoemake's algorithm impl. is taken from this repo by permission:      |
 |   https://github.com/erich666/GraphicsGems/blob/master/gemsiv/euler_angle  |
 |                                                                            |
 | cglm doesn't claim the ownership of GraphicsGems source codes              |
 | and the algorithm itself. But cglm may change variable names or some piece |
 | of codes in order to apply optimizations or to make it usable in cglm.     |
 |                                                                            |
 | Related issue: https://github.com/recp/cglm/issues/30                      |
 |                                                                            |
 * -------------------------- GraphicsGems EULA ----------------------------- *
 | Related EULA for GraphicsGems can be found at below, plus in CREDITS:      |
 |   http://www.realtimerendering.com/resources/GraphicsGems/                 |
 |                                                                            |
 | EULA: The Graphics Gems code is copyright-protected. In other words, you   |
 | cannot claim the text of the code as your own and resell it. Using the     |
 | code is permitted in any program, product, or library, non-commercial or   |
 | commercial. Giving credit is not required, though is a nice gesture.       |
 | The code comes as-is, and if there are any flaws or problems with any Gems |
 | code, nobody involved with Gems - authors, editors, publishers, or         |
 | webmasters - are to be held responsible. Basically, don't be a jerk, and   |
 | remember that anything free comes with no guarantee.                       |
 * -------------------------------- END --------------------------------------*/
```

it says that `Giving credit is not required, though is a nice gesture.` so **cglm** gives credit in both header and CREDITS file. 

The old Euler API probably will be deprecated if anyone will not complain for that.

---

cglm applies a few changes for names. The api will be like this:

1. `void glm_eul_mat4(vec3 ea, int order, mat4 dest)`

Euler order macros:

```C
/*! Static axes */
#define GLM_EUL_XYZs    EulOrd(0,EulParEven,EulRepNo,EulFrmS)
#define GLM_EUL_XYXs    EulOrd(0,EulParEven,EulRepYes,EulFrmS)
#define GLM_EUL_XZYs    EulOrd(0,EulParOdd,EulRepNo,EulFrmS)
#define GLM_EUL_XZXs    EulOrd(0,EulParOdd,EulRepYes,EulFrmS)
#define GLM_EUL_YZXs    EulOrd(1,EulParEven,EulRepNo,EulFrmS)
#define GLM_EUL_YZYs    EulOrd(1,EulParEven,EulRepYes,EulFrmS)
#define GLM_EUL_YXZs    EulOrd(1,EulParOdd,EulRepNo,EulFrmS)
#define GLM_EUL_YXYs    EulOrd(1,EulParOdd,EulRepYes,EulFrmS)
#define GLM_EUL_ZXYs    EulOrd(2,EulParEven,EulRepNo,EulFrmS)
#define GLM_EUL_ZXZs    EulOrd(2,EulParEven,EulRepYes,EulFrmS)
#define GLM_EUL_ZYXs    EulOrd(2,EulParOdd,EulRepNo,EulFrmS)
#define GLM_EUL_ZYZs    EulOrd(2,EulParOdd,EulRepYes,EulFrmS)

/*! Rotating axes */
#define GLM_EUL_ZYXr    EulOrd(0,EulParEven,EulRepNo,EulFrmR)
#define GLM_EUL_XYXr    EulOrd(0,EulParEven,EulRepYes,EulFrmR)
#define GLM_EUL_YZXr    EulOrd(0,EulParOdd,EulRepNo,EulFrmR)
#define GLM_EUL_XZXr    EulOrd(0,EulParOdd,EulRepYes,EulFrmR)
#define GLM_EUL_XZYr    EulOrd(1,EulParEven,EulRepNo,EulFrmR)
#define GLM_EUL_YZYr    EulOrd(1,EulParEven,EulRepYes,EulFrmR)
#define GLM_EUL_ZXYr    EulOrd(1,EulParOdd,EulRepNo,EulFrmR)
#define GLM_EUL_YXYr    EulOrd(1,EulParOdd,EulRepYes,EulFrmR)
#define GLM_EUL_YXZr    EulOrd(2,EulParEven,EulRepNo,EulFrmR)
#define GLM_EUL_ZXZr    EulOrd(2,EulParEven,EulRepYes,EulFrmR)
#define GLM_EUL_XYZr    EulOrd(2,EulParOdd,EulRepNo,EulFrmR)
#define GLM_EUL_ZYZr    EulOrd(2,EulParOdd,EulRepYes,EulFrmR)
```

I want to make `EulOrd(2,EulParOdd,EulRepYes,EulFrmR)` pre-calculated in order to remove a few macro definitions

Related issue: https://github.com/recp/cglm/issues/30