### PR TITLE
Link contributors' avatars to the correct page

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ You can pass matrices the same way to other APIs e.g. Vulkan, DX...
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="graphs/contributors"><img src="https://opencollective.com/cglm/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/recp/cglm/graphs/contributors"><img src="https://opencollective.com/cglm/contributors.svg?width=890&button=false" /></a>
 
 
 ## Backers


### PR DESCRIPTION
Using an absolute link should fix this. Tested it on my fork, where it works.

Closes #133