### PR TITLE
Fix some documentation mistakes

### DIFF
--- a/docs/source/vec3.rst
+++ b/docs/source/vec3.rst
@@ -435,8 +435,8 @@ Functions documentation
     squared distance between two vectors
 
     Parameters:
-      | *[in]*  **mat**   vector1
-      | *[in]*  **row1**  vector2
+      | *[in]*  **v1**  vector1
+      | *[in]*  **v2**  vector2
 
     Returns:
       | squared distance (distance * distance)
@@ -446,8 +446,8 @@ Functions documentation
     distance between two vectors
 
     Parameters:
-      | *[in]*  **mat**   vector1
-      | *[in]*  **row1**  vector2
+      | *[in]*  **v1**  vector1
+      | *[in]*  **v2**  vector2
 
     Returns:
       | distance
@@ -475,7 +475,7 @@ Functions documentation
     possible orthogonal/perpendicular vector
 
     Parameters:
-      | *[in]*  **mat**   vector
+      | *[in]*  **v**     vector
       | *[out]* **dest**  orthogonal/perpendicular vector
 
 .. c:function:: void  glm_vec3_clamp(vec3 v, float minVal, float maxVal)


### PR DESCRIPTION
I found another documentation mistake, so I decided to just go through `vec3.rst` and check whether the parameter names in the function call match the parameter name in the description. These are the errors I found.