### PR TITLE
Print Improvements

### DIFF
--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -28,6 +28,23 @@ Example to print mat4 matrix:
 (you probably will in some cases), you can change it temporary.
 cglm may provide precision parameter in the future
 
+Changes since **v0.7.3**:
+* Now mis-alignment of columns are fixed: larger numbers are printed via %g and others are printed via %f. Column withs are calculated before print.
+* Now values are colorful ;)
+* Some print improvements
+* New options with default values:
+
+.. code-block:: c
+
+    #define CGLM_PRINT_PRECISION    5
+    #define CGLM_PRINT_MAX_TO_SHORT 1e5
+    #define CGLM_PRINT_COLOR        "\033[36m"
+    #define CGLM_PRINT_COLOR_RESET  "\033[0m"
+
+* Inline prints are only enabled in DEBUG mode and if **CGLM_DEFINE_PRINTS** is defined.
+
+Check options page.
+
 Table of contents (click to go):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/opt.rst
+++ b/docs/source/opt.rst
@@ -50,3 +50,24 @@ You have to extra options for dot product: **CGLM_SSE4_DOT** and **CGLM_SSE3_DOT
 - If **SSE3** is enabled then you can define **CGLM_SSE3_DOT** to force cglm to use **_mm_hadd_ps** instructions.
 
 otherwise cglm will use custom cglm's hadd functions which are optimized too.
+
+Print Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. **CGLM_DEFINE_PRINTS**
+2. **CGLM_NO_PRINTS_NOOP**
+
+Inline prints are only enabled in DEBUG mode and if **CGLM_DEFINE_PRINTS** is defined.
+If DEBUG is not enabled then print function bodies will be emptied to eliminate print function calls.
+You can disable this feature too by defining **CGLM_NO_PRINTS_NOOP** macro top of cglm headers.
+
+3. **CGLM_PRINT_PRECISION**    5
+
+precision.
+
+4. **CGLM_PRINT_MAX_TO_SHORT** 1e5
+
+if a number is greater than this value then %g will be used, since this is shorten print you won't be able to see high precision.
+
+5. **CGLM_PRINT_COLOR**        "\033[36m"
+6. **CGLM_PRINT_COLOR_RESET**  "\033[0m"

--- a/include/cglm/call/io.h
+++ b/include/cglm/call/io.h
@@ -7,6 +7,8 @@
 
 #ifndef cglmc_io_h
 #define cglmc_io_h
+#if (defined(DEBUG) || defined(CGLM_DEFINE_PRINTS)) || defined(CGLM_LIB_SRC)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -40,5 +42,6 @@ glmc_versor_print(versor vec,
 
 #ifdef __cplusplus
 }
+#endif
 #endif
 #endif /* cglmc_io_h */

--- a/include/cglm/call/io.h
+++ b/include/cglm/call/io.h
@@ -7,7 +7,6 @@
 
 #ifndef cglmc_io_h
 #define cglmc_io_h
-#if (defined(DEBUG) || defined(CGLM_DEFINE_PRINTS)) || defined(CGLM_LIB_SRC)
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +41,5 @@ glmc_versor_print(versor vec,
 
 #ifdef __cplusplus
 }
-#endif
 #endif
 #endif /* cglmc_io_h */

--- a/include/cglm/common.h
+++ b/include/cglm/common.h
@@ -8,7 +8,8 @@
 #ifndef cglm_common_h
 #define cglm_common_h
 
-#define _USE_MATH_DEFINES /* for windows */
+#define _USE_MATH_DEFINES       /* for windows */
+#define _CRT_SECURE_NO_WARNINGS /* for windows */
 
 #include <stdint.h>
 #include <stddef.h>

--- a/include/cglm/euler.h
+++ b/include/cglm/euler.h
@@ -55,8 +55,6 @@ typedef enum glm_euler_seq {
   GLM_EULER_ZYX = 2 << 0 | 1 << 2 | 0 << 4
 } glm_euler_seq;
 
-typedef glm_euler_seq glm_euler_sq;
-
 CGLM_INLINE
 glm_euler_seq
 glm_euler_order(int ord[3]) {

--- a/include/cglm/io.h
+++ b/include/cglm/io.h
@@ -23,61 +23,91 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define CGLM_PRINT_PRECISION    5
+#define CGLM_PRINT_MAX_TO_SHORT 1e5
+#define CGLM_PRINT_COLOR        "\033[36m"
+#define CGLM_PRINT_COLOR_RESET  "\033[0m"
+
 CGLM_INLINE
 void
 glm_mat4_print(mat4              matrix,
                FILE * __restrict ostream) {
-  int i;
-  int j;
+  char buff[16];
+  int  i, j, cw[4], cwi;
 
 #define m 4
 #define n 4
 
-  fprintf(ostream, "Matrix (float%dx%d):\n", m, n);
+  fprintf(ostream, "Matrix (float%dx%d): " CGLM_PRINT_COLOR "\n" , m, n);
+
+  cw[0] = cw[1] = cw[2] = cw[3] = 0;
 
   for (i = 0; i < m; i++) {
-    fprintf(ostream, "\t|");
     for (j = 0; j < n; j++) {
-      fprintf(ostream, "%0.4f", matrix[j][i]);;
-
-      if (j != n - 1)
-        fprintf(ostream, "\t");
+      if (matrix[i][j] < CGLM_PRINT_MAX_TO_SHORT)
+        cwi = sprintf(buff, "% .*f", CGLM_PRINT_PRECISION, matrix[i][j]);
+      else
+        cwi = sprintf(buff, "% g", matrix[i][j]);
+      cw[i] = GLM_MAX(cw[i], cwi);
     }
-
-    fprintf(ostream, "|\n");
   }
 
-  fprintf(ostream, "\n");
+  for (i = 0; i < m; i++) {
+    fprintf(ostream, "  |");
+
+    for (j = 0; j < n; j++)
+      if (matrix[i][j] < CGLM_PRINT_MAX_TO_SHORT)
+        fprintf(ostream, " % *.*f", cw[j], CGLM_PRINT_PRECISION, matrix[j][i]);
+      else
+        fprintf(ostream, " % *g", cw[j], matrix[j][i]);
+
+    fprintf(ostream, "  |\n");
+  }
+
+  fprintf(ostream, CGLM_PRINT_COLOR_RESET "\n");
 
 #undef m
 #undef n
 }
 
+
 CGLM_INLINE
 void
 glm_mat3_print(mat3              matrix,
                FILE * __restrict ostream) {
-  int i;
-  int j;
+  char buff[16];
+  int  i, j, cw[4], cwi;
 
 #define m 3
 #define n 3
 
-  fprintf(ostream, "Matrix (float%dx%d):\n", m, n);
+  fprintf(ostream, "Matrix (float%dx%d): " CGLM_PRINT_COLOR "\n", m, n);
+
+  cw[0] = cw[1] = cw[2] = 0;
 
   for (i = 0; i < m; i++) {
-    fprintf(ostream, "\t|");
     for (j = 0; j < n; j++) {
-      fprintf(ostream, "%0.4f", matrix[j][i]);;
-
-      if (j != n - 1)
-        fprintf(ostream, "\t");
+      if (matrix[i][j] < CGLM_PRINT_MAX_TO_SHORT)
+        cwi = sprintf(buff, "% .*f", CGLM_PRINT_PRECISION, matrix[i][j]);
+      else
+        cwi = sprintf(buff, "% g", matrix[i][j]);
+      cw[i] = GLM_MAX(cw[i], cwi);
     }
-
-    fprintf(ostream, "|\n");
   }
 
-  fprintf(ostream, "\n");
+  for (i = 0; i < m; i++) {
+    fprintf(ostream, "  |");
+    
+    for (j = 0; j < n; j++)
+      if (matrix[i][j] < CGLM_PRINT_MAX_TO_SHORT)
+        fprintf(ostream, " % *.*f", cw[j], CGLM_PRINT_PRECISION, matrix[j][i]);
+      else
+        fprintf(ostream, " % *g", cw[j], matrix[j][i]);
+    
+    fprintf(ostream, "  |\n");
+  }
+
+  fprintf(ostream, CGLM_PRINT_COLOR_RESET "\n");
 
 #undef m
 #undef n
@@ -87,27 +117,39 @@ CGLM_INLINE
 void
 glm_mat2_print(mat2              matrix,
                FILE * __restrict ostream) {
-  int i;
-  int j;
+  char buff[16];
+  int  i, j, cw[4], cwi;
 
 #define m 2
 #define n 2
 
-  fprintf(ostream, "Matrix (float%dx%d):\n", m, n);
+  fprintf(ostream, "Matrix (float%dx%d): " CGLM_PRINT_COLOR "\n", m, n);
+
+  cw[0] = cw[1] = 0;
 
   for (i = 0; i < m; i++) {
-    fprintf(ostream, "\t|");
     for (j = 0; j < n; j++) {
-      fprintf(ostream, "%0.4f", matrix[j][i]);;
-
-      if (j != n - 1)
-        fprintf(ostream, "\t");
+      if (matrix[i][j] < CGLM_PRINT_MAX_TO_SHORT)
+        cwi = sprintf(buff, "% .*f", CGLM_PRINT_PRECISION, matrix[i][j]);
+      else
+        cwi = sprintf(buff, "% g", matrix[i][j]);
+      cw[i] = GLM_MAX(cw[i], cwi);
     }
-
-    fprintf(ostream, "|\n");
   }
 
-  fprintf(ostream, "\n");
+  for (i = 0; i < m; i++) {
+    fprintf(ostream, "  |");
+    
+    for (j = 0; j < n; j++)
+      if (matrix[i][j] < CGLM_PRINT_MAX_TO_SHORT)
+        fprintf(ostream, " % *.*f", cw[j], CGLM_PRINT_PRECISION, matrix[j][i]);
+      else
+        fprintf(ostream, " % *g", cw[j], matrix[j][i]);
+    
+    fprintf(ostream, "  |\n");
+  }
+
+  fprintf(ostream, CGLM_PRINT_COLOR_RESET "\n");
 
 #undef m
 #undef n
@@ -121,16 +163,16 @@ glm_vec4_print(vec4              vec,
 
 #define m 4
 
-  fprintf(ostream, "Vector (float%d):\n\t|", m);
+  fprintf(ostream, "Vector (float%d): " CGLM_PRINT_COLOR "\n  (", m);
 
   for (i = 0; i < m; i++) {
-    fprintf(ostream, "%0.4f", vec[i]);
-
-    if (i != m - 1)
-      fprintf(ostream, "\t");
+    if (vec[i] < CGLM_PRINT_MAX_TO_SHORT)
+      fprintf(ostream, " % .*f", CGLM_PRINT_PRECISION, vec[i]);
+    else
+      fprintf(ostream, " % g", vec[i]);
   }
 
-  fprintf(ostream, "|\n\n");
+  fprintf(ostream, "  )" CGLM_PRINT_COLOR_RESET "\n\n");
 
 #undef m
 }
@@ -143,16 +185,16 @@ glm_vec3_print(vec3              vec,
 
 #define m 3
 
-  fprintf(ostream, "Vector (float%d):\n\t|", m);
+  fprintf(ostream, "Vector (float%d): " CGLM_PRINT_COLOR "\n  (", m);
 
   for (i = 0; i < m; i++) {
-    fprintf(ostream, "%0.4f", vec[i]);
-
-    if (i != m - 1)
-      fprintf(ostream, "\t");
+    if (vec[i] < CGLM_PRINT_MAX_TO_SHORT)
+      fprintf(ostream, " % .*f", CGLM_PRINT_PRECISION, vec[i]);
+    else
+      fprintf(ostream, " % g", vec[i]);
   }
 
-  fprintf(ostream, "|\n\n");
+  fprintf(ostream, "  )" CGLM_PRINT_COLOR_RESET "\n\n");
 
 #undef m
 }
@@ -165,16 +207,12 @@ glm_ivec3_print(ivec3             vec,
 
 #define m 3
 
-  fprintf(ostream, "Vector (int%d):\n\t|", m);
+  fprintf(ostream, "Vector (int%d): " CGLM_PRINT_COLOR "\n  (", m);
 
-  for (i = 0; i < m; i++) {
-    fprintf(ostream, "%d", vec[i]);
+  for (i = 0; i < m; i++)
+    fprintf(ostream, " % d", vec[i]);
 
-    if (i != m - 1)
-      fprintf(ostream, "\t");
-  }
-
-  fprintf(ostream, "|\n\n");
+  fprintf(ostream, "  )" CGLM_PRINT_COLOR_RESET "\n\n");
   
 #undef m
 }
@@ -187,16 +225,16 @@ glm_vec2_print(vec2              vec,
 
 #define m 2
 
-  fprintf(ostream, "Vector (float%d):\n\t|", m);
+  fprintf(ostream, "Vector (float%d): " CGLM_PRINT_COLOR "\n  (", m);
 
   for (i = 0; i < m; i++) {
-    fprintf(ostream, "%0.4f", vec[i]);
-
-    if (i != m - 1)
-      fprintf(ostream, "\t");
+    if (vec[i] < CGLM_PRINT_MAX_TO_SHORT)
+      fprintf(ostream, " % .*f", CGLM_PRINT_PRECISION, vec[i]);
+    else
+      fprintf(ostream, " % g", vec[i]);
   }
 
-  fprintf(ostream, "|\n\n");
+  fprintf(ostream, "  )" CGLM_PRINT_COLOR_RESET "\n\n");
 
 #undef m
 }
@@ -209,16 +247,17 @@ glm_versor_print(versor            vec,
 
 #define m 4
 
-  fprintf(ostream, "Versor (float%d):\n\t|", m);
+  fprintf(ostream, "Quaternion (float%d): " CGLM_PRINT_COLOR "\n  (", m);
 
   for (i = 0; i < m; i++) {
-    fprintf(ostream, "%0.4f", vec[i]);
-
-    if (i != m - 1)
-      fprintf(ostream, "\t");
+    if (vec[i] < CGLM_PRINT_MAX_TO_SHORT)
+      fprintf(ostream, " % .*f", CGLM_PRINT_PRECISION, vec[i]);
+    else
+      fprintf(ostream, " % g", vec[i]);
   }
 
-  fprintf(ostream, "|\n\n");
+
+  fprintf(ostream, "  )" CGLM_PRINT_COLOR_RESET "\n\n");
 
 #undef m
 }
@@ -232,22 +271,22 @@ glm_aabb_print(vec3                    bbox[2],
 
 #define m 3
 
-  fprintf(ostream, "AABB (%s):\n", tag ? tag: "float");
+  fprintf(ostream, "AABB (%s): " CGLM_PRINT_COLOR "\n", tag ? tag: "float");
 
   for (i = 0; i < 2; i++) {
-    fprintf(ostream, "\t|");
-
+    fprintf(ostream, "  (");
+    
     for (j = 0; j < m; j++) {
-      fprintf(ostream, "%0.4f", bbox[i][j]);
-
-      if (j != m - 1)
-        fprintf(ostream, "\t");
+      if (bbox[i][j] < CGLM_PRINT_MAX_TO_SHORT)
+        fprintf(ostream, " % .*f", CGLM_PRINT_PRECISION, bbox[i][j]);
+      else
+        fprintf(ostream, " % g", bbox[i][j]);
     }
 
-    fprintf(ostream, "|\n");
+    fprintf(ostream, "  )\n");
   }
 
-  fprintf(ostream, "\n");
+  fprintf(ostream, CGLM_PRINT_COLOR_RESET "\n");
 
 #undef m
 }

--- a/include/cglm/io.h
+++ b/include/cglm/io.h
@@ -17,7 +17,8 @@
 
 #ifndef cglm_io_h
 #define cglm_io_h
-#if defined(DEBUG) || defined(CGLM_DEFINE_PRINTS) || defined(CGLM_LIB_SRC)
+#if defined(DEBUG) || defined(_DEBUG) \
+   || defined(CGLM_DEFINE_PRINTS) || defined(CGLM_LIB_SRC)
 
 #include "common.h"
 

--- a/include/cglm/io.h
+++ b/include/cglm/io.h
@@ -17,6 +17,7 @@
 
 #ifndef cglm_io_h
 #define cglm_io_h
+#if defined(DEBUG) || defined(CGLM_DEFINE_PRINTS) || defined(CGLM_LIB_SRC)
 
 #include "common.h"
 
@@ -291,4 +292,22 @@ glm_aabb_print(vec3                    bbox[2],
 #undef m
 }
 
+#elif !defined(CGLM_NO_PRINTS_NOOP)
+
+#include "common.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* NOOP: Remove print from DEBUG */
+CGLM_INLINE void glm_mat4_print(mat4 matrix, FILE *o) { }
+CGLM_INLINE void glm_mat3_print(mat3 matrix, FILE *o) { }
+CGLM_INLINE void glm_mat2_print(mat2 matrix, FILE *o) { }
+CGLM_INLINE void glm_vec4_print(vec4 vec, FILE *o) { }
+CGLM_INLINE void glm_vec3_print(vec3 vec, FILE *o) { }
+CGLM_INLINE void glm_ivec3_print(ivec3 vec, FILE *o) { }
+CGLM_INLINE void glm_vec2_print(vec2 vec, FILE *o) { }
+CGLM_INLINE void glm_versor_print(versor vec, FILE *o) { }
+CGLM_INLINE void glm_aabb_print(vec3 bbox[2], const char *t, FILE *o) { }
+#endif
 #endif /* cglm_io_h */

--- a/src/io.c
+++ b/src/io.c
@@ -5,6 +5,8 @@
  * Full license can be found in the LICENSE file
  */
 
+#define CGLM_LIB_SRC
+
 #include "../include/cglm/cglm.h"
 #include "../include/cglm/call.h"
 

--- a/test/include/common.h
+++ b/test/include/common.h
@@ -8,6 +8,9 @@
 #ifndef tests_common_h
 #define tests_common_h
 
+#define _USE_MATH_DEFINES       /* for windows */
+#define _CRT_SECURE_NO_WARNINGS /* for windows */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
* **Now mis-alignment of columns are fixed: larger numbers are printed via %g and others are printed via %f. Column withs are calculated before print.**
* Now values are colorful ;)

<img width="366" alt="Screen Shot 2020-04-30 at 11 51 17 PM" src="https://user-images.githubusercontent.com/1264894/80757844-7d51cc00-8b3d-11ea-974f-0c100bdf5add.png">

* New options with default values:

```C

    #define CGLM_PRINT_PRECISION    5
    #define CGLM_PRINT_MAX_TO_SHORT 1e5
    #define CGLM_PRINT_COLOR        "\033[36m"
    #define CGLM_PRINT_COLOR_RESET  "\033[0m"

```

* Inline prints are only enabled in **DEBUG** mode and if **CGLM_DEFINE_PRINTS** is defined.
* You can still call library-print functions e.g. glmc_print... 

To make codes unbroken cglm makes inline prints empty-body (if **DEBUG** and **CGLM_DEFINE_PRINTS** are not defined):

```C
CGLM_INLINE void glm_mat4_print(mat4 matrix, FILE *o) { }
```

this also can be disabled by defining `CGLM_NO_PRINTS_NOOP` macro. 🎉

Define `CGLM_PRINT_PRECISION` to change print precision, default is increased to 5 from 4 ... 