### PR TITLE
win32: fix symbol exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(CGLM_USE_C99)
 endif()
 
 if(MSVC)
-  add_definitions(-DNDEBUG -D_WINDOWS -D_USRDLL -DCGLM_EXPORTS -DCGLM_DLL)
+  add_definitions(-DNDEBUG -D_WINDOWS -D_USRDLL)
   add_compile_options(/W3 /Ox /Gy /Oi /TC)
   
   # Ref: https://skia.googlesource.com/third_party/sdl/+/refs/heads/master/CMakeLists.txt#225
@@ -74,6 +74,11 @@ add_library(${PROJECT_NAME}
   src/ray.c
   src/affine2d.c
   )
+
+if(CGLM_SHARED)
+  add_definitions(-DCGLM_EXPORTS)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DCGLM_DLL)
+endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
                               VERSION ${PROJECT_VERSION} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,8 @@ add_library(${PROJECT_NAME}
 
 if(CGLM_SHARED)
   add_definitions(-DCGLM_EXPORTS)
-  target_compile_definitions(${PROJECT_NAME} PUBLIC -DCGLM_DLL)
+else()
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DCGLM_STATIC)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/include/cglm/common.h
+++ b/include/cglm/common.h
@@ -23,12 +23,12 @@
 #include <stdbool.h>
 
 #if defined(_MSC_VER)
-#  ifdef CGLM_EXPORTS
-#    define CGLM_EXPORT __declspec(dllexport)
-#  elif defined(CGLM_DLL)
-#    define CGLM_EXPORT __declspec(dllimport)
-#  else
+#  ifdef CGLM_STATIC
 #    define CGLM_EXPORT
+#  elif defined(CGLM_EXPORTS)
+#    define CGLM_EXPORT __declspec(dllexport)
+#  else
+#    define CGLM_EXPORT __declspec(dllimport)
 #  endif
 #  define CGLM_INLINE __forceinline
 #else

--- a/include/cglm/common.h
+++ b/include/cglm/common.h
@@ -23,7 +23,7 @@
 #include <stdbool.h>
 
 #if defined(_MSC_VER)
-#  if defined(CGLM_DLL) && defined(CGLM_EXPORTS)
+#  ifdef CGLM_EXPORTS
 #    define CGLM_EXPORT __declspec(dllexport)
 #  elif defined(CGLM_DLL)
 #    define CGLM_EXPORT __declspec(dllimport)

--- a/include/cglm/common.h
+++ b/include/cglm/common.h
@@ -23,10 +23,12 @@
 #include <stdbool.h>
 
 #if defined(_MSC_VER)
-#  ifdef CGLM_DLL
+#  if defined(CGLM_DLL) && defined(CGLM_EXPORTS)
 #    define CGLM_EXPORT __declspec(dllexport)
-#  else
+#  elif defined(CGLM_DLL)
 #    define CGLM_EXPORT __declspec(dllimport)
+#  else
+#    define CGLM_EXPORT
 #  endif
 #  define CGLM_INLINE __forceinline
 #else

--- a/win/cglm.vcxproj
+++ b/win/cglm.vcxproj
@@ -209,7 +209,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CGLM_EXPORTS;CGLM_DLL;%(PreprocessorDefinitions);CGLM_DLL</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CGLM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <PrecompiledHeaderFile />
@@ -225,7 +225,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;CGLM_EXPORTS;CGLM_DLL;%(PreprocessorDefinitions);CGLM_DLL</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;CGLM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -246,7 +246,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CGLM_EXPORTS;CGLM_DLL;%(PreprocessorDefinitions);CGLM_DLL</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CGLM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <PrecompiledHeaderFile />
       <CompileAs>CompileAsC</CompileAs>
@@ -266,7 +266,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;CGLM_EXPORTS;CGLM_DLL;%(PreprocessorDefinitions);CGLM_DLL</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;CGLM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <PrecompiledHeaderFile />
       <CompileAs>CompileAsC</CompileAs>


### PR DESCRIPTION
Add `CGLM_STATIC` to disable the dllimport/dllexports for static builds and only export symbols for shared builds, this is needed because symbols should only appear with `dllimport` to _users_ of dynamic builds, while static builds should not define any attributes.

CMake / MSBuild hides these issues with workarounds but it causes problems with other tools. This change should be invisible to existing projects.

The rationale for replacing `CGLM_DLL` with `CGLM_EXPORTS` in `common.h` is that the latter is very close to what CMake defines automatically for shared builds (this would be `cglm_EXPORTS` in this case) and having both `CGLM_STATIC` and `CGLM_DLL` is confusing.