### PR TITLE
gcc: fix warnings

### DIFF
--- a/include/cglm/io.h
+++ b/include/cglm/io.h
@@ -301,15 +301,15 @@ glm_aabb_print(vec3                    bbox[2],
 #include <stdlib.h>
 
 /* NOOP: Remove print from DEBUG */
-#define glm_mat4_print(...)
-#define glm_mat3_print(...)
-#define glm_mat2_print(...)
-#define glm_vec4_print(...)
-#define glm_vec3_print(...)
-#define glm_ivec3_print(...)
-#define glm_vec2_print(...)
-#define glm_versor_print(...)
-#define glm_aabb_print(...)
+#define glm_mat4_print(v, s) (void)v; (void)s;
+#define glm_mat3_print(v, s) (void)v; (void)s;
+#define glm_mat2_print(v, s) (void)v; (void)s;
+#define glm_vec4_print(v, s) (void)v; (void)s;
+#define glm_vec3_print(v, s) (void)v; (void)s;
+#define glm_ivec3_print(v, s) (void)v; (void)s;
+#define glm_vec2_print(v, s) (void)v; (void)s;
+#define glm_versor_print(v, s) (void)v; (void)s;
+#define glm_aabb_print(v, t, s) (void)v; (void)t; (void)s;
 
 #endif
 #endif /* cglm_io_h */

--- a/test/include/common.h
+++ b/test/include/common.h
@@ -16,6 +16,10 @@
 #  define _CRT_SECURE_NO_WARNINGS /* for windows */
 #endif
 
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE /* for drand48() */
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/test/runner.c
+++ b/test/runner.c
@@ -18,6 +18,8 @@ main(int argc, const char * argv[]) {
   test_status_t st;
   int32_t       i, count, passed, failed, maxlen;
   double        start, end, elapsed, total;
+  (void)argc;
+  (void)argv;
 
   passed = failed = maxlen  = 0;
   total  = 0.0;


### PR DESCRIPTION
Fixes an `implicit declaration` and `unused parameter` warnings.

<details>
  <summary>Click to expand!</summary>

```
In file included from ../include/cglm/struct.h:27,
                 from ../test/src/../include/common.h:24,
                 from ../test/src/test_common.h:11,
                 from ../test/src/test_vec2.h:8,
                 from ../test/src/tests.c:15:
../include/cglm/struct/io.h: In function ‘glms_mat4_print’:
../include/cglm/struct/io.h:30:35: warning: unused parameter ‘matrix’ [-Wunused-parameter]
 glms_mat4_print(mat4s             matrix,
                 ~~~~~~~~~~~~~~~~~~^~~~~~
../include/cglm/struct/io.h:31:35: warning: unused parameter ‘ostream’ [-Wunused-parameter]
                 FILE * __restrict ostream) {
                 ~~~~~~~~~~~~~~~~~~^~~~~~~
../include/cglm/struct/io.h: In function ‘glms_mat3_print’:
../include/cglm/struct/io.h:38:35: warning: unused parameter ‘matrix’ [-Wunused-parameter]
 glms_mat3_print(mat3s             matrix,
                 ~~~~~~~~~~~~~~~~~~^~~~~~
../include/cglm/struct/io.h:39:35: warning: unused parameter ‘ostream’ [-Wunused-parameter]
                 FILE * __restrict ostream) {
                 ~~~~~~~~~~~~~~~~~~^~~~~~~
../include/cglm/struct/io.h: In function ‘glms_vec4_print’:
../include/cglm/struct/io.h:45:35: warning: unused parameter ‘vec’ [-Wunused-parameter]
 glms_vec4_print(vec4s             vec,
                 ~~~~~~~~~~~~~~~~~~^~~
../include/cglm/struct/io.h:46:35: warning: unused parameter ‘ostream’ [-Wunused-parameter]
                 FILE * __restrict ostream) {
                 ~~~~~~~~~~~~~~~~~~^~~~~~~
../include/cglm/struct/io.h: In function ‘glms_vec3_print’:
../include/cglm/struct/io.h:52:35: warning: unused parameter ‘vec’ [-Wunused-parameter]
 glms_vec3_print(vec3s             vec,
                 ~~~~~~~~~~~~~~~~~~^~~
../include/cglm/struct/io.h:53:35: warning: unused parameter ‘ostream’ [-Wunused-parameter]
                 FILE * __restrict ostream) {
                 ~~~~~~~~~~~~~~~~~~^~~~~~~
../include/cglm/struct/io.h: In function ‘glms_ivec3_print’:
../include/cglm/struct/io.h:59:36: warning: unused parameter ‘vec’ [-Wunused-parameter]
 glms_ivec3_print(ivec3s            vec,
                  ~~~~~~~~~~~~~~~~~~^~~
../include/cglm/struct/io.h:60:36: warning: unused parameter ‘ostream’ [-Wunused-parameter]
                  FILE * __restrict ostream) {
                  ~~~~~~~~~~~~~~~~~~^~~~~~~
../include/cglm/struct/io.h: In function ‘glms_versor_print’:
../include/cglm/struct/io.h:66:37: warning: unused parameter ‘vec’ [-Wunused-parameter]
 glms_versor_print(versors           vec,
                   ~~~~~~~~~~~~~~~~~~^~~
../include/cglm/struct/io.h:67:37: warning: unused parameter ‘ostream’ [-Wunused-parameter]
                   FILE * __restrict ostream) {
                   ~~~~~~~~~~~~~~~~~~^~~~~~~
../include/cglm/struct/io.h: In function ‘glms_aabb_print’:
../include/cglm/struct/io.h:74:41: warning: unused parameter ‘tag’ [-Wunused-parameter]
                 const char * __restrict tag,
                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~
../include/cglm/struct/io.h:75:41: warning: unused parameter ‘ostream’ [-Wunused-parameter]
                 FILE       * __restrict ostream) {
                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
In file included from ../test/src/tests.c:26:
../test/src/test_affine_mat.h: In function ‘test_glm_mul_rot’:
../test/src/test_affine_mat.h:45:18: warning: implicit declaration of function ‘drand48’; did you mean ‘srand’? [-Wimplicit-function-declaration]
   glm_rotate(m1, drand48(), (vec3){drand48(), drand48(), drand48()});
                  ^~~~~~~
                  srand
```

</details>