### PR TITLE
Add meson build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,34 @@ add_subdirectory(external/cglm/)
 # or you can use find_package to configure cglm
 ```
 
+### Meson (All platforms)
+
+```bash
+$ meson build # [Optional] --default-library=static
+$ cd build
+$ ninja
+$ sudo ninja install # [Optional]
+```
+
+##### Meson options with Defaults:
+
+```meson
+c_std=c11
+buildtype=release
+default_library=shared
+```
+#### Use with your Meson project
+* Example:
+```meson
+# Clone cglm or create a cglm.wrap under <source_root>/subprojects
+project('name', 'c')
+
+cglm_dep = dependency('cglm', fallback : 'cglm', 'cglm_dep')
+
+executable('exe', 'src/main.c', dependencies : cglm_dep)
+```
+
+
 ### Unix (Autotools)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ $ sudo ninja install # [Optional]
 c_std=c11
 buildtype=release
 default_library=shared
+enable_tests=false # to run tests: ninja test
 ```
 #### Use with your Meson project
 * Example:

--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -47,6 +47,41 @@ If you don't want to install **cglm** to your system's folder you can get static
   
   add_subdirectory(external/cglm/)
 
+Meson (All platforms):
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+  :linenos:
+
+  $ meson build # [Optional] --default-library=static
+  $ cd build
+  $ ninja
+  $ sudo ninja install # [Optional]
+
+**Meson Options:**
+
+.. code-block:: CMake
+  :linenos:
+
+  c_std=c11
+  buildtype=release
+  default_library=shared
+  enable_tests=false # to run tests: ninja test
+
+
+**Use with your CMake project example**
+
+.. code-block:: CMake
+  :linenos:
+
+  # Clone cglm or create a cglm.wrap under <source_root>/subprojects
+  project('name', 'c')
+  
+  cglm_dep = dependency('cglm', fallback : 'cglm', 'cglm_dep')
+  
+  executable('exe', 'src/main.c', dependencies : cglm_dep)
+
+
 Unix (Autotools):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/meson.build
+++ b/meson.build
@@ -83,16 +83,17 @@ pkg.generate(
     description : 'OpenGL Mathematics (glm) for C'
 )
 
+if get_option('build_tests') == true
 
 test_src = files(
-  'test/runner.c',
-  'test/src/test_euler.c',
-  'test/src/test_bezier.c',
-  'test/src/test_cam.c',
-  'test/src/test_struct.c',
-  'test/src/test_clamp.c',
-  'test/src/test_common.c',
-  'test/src/tests.c'
+    'test/runner.c',
+    'test/src/test_euler.c',
+    'test/src/test_bezier.c',
+    'test/src/test_cam.c',
+    'test/src/test_struct.c',
+    'test/src/test_clamp.c',
+    'test/src/test_common.c',
+    'test/src/tests.c'
 )
 
 test_exe = executable('tests', 
@@ -102,3 +103,5 @@ test_exe = executable('tests',
 )
 
 test('cglm.tests', test_exe)
+
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,104 @@
+project('cglm', 'c',
+    version : '0.7.7', 
+    license : 'mit',
+    default_options : [
+        'c_std=c11',
+        'werror=true',
+        'warning_level=2',
+        'buildtype=release'
+    ]
+)
+
+cc = meson.get_compiler('c')
+
+cglm_deps = cc.find_library('m', required : false)
+
+cglm_args = []
+build_args = []
+
+if get_option('default_library') == 'static'
+    cglm_args = '-DCGLM_STATIC'
+endif
+
+if host_machine.system() == 'windows'
+    build_args = '-DCGLM_EXPORTS'
+endif
+
+cglm_inc = include_directories('include')
+
+cglm_src = files(
+    'src/affine.c',
+    'src/affine2d.c',
+    'src/bezier.c',
+    'src/box.c',
+    'src/cam.c',
+    'src/curve.c',
+    'src/ease.c',
+    'src/euler.c',
+    'src/frustum.c',
+    'src/io.c',
+    'src/mat2.c',
+    'src/mat3.c',
+    'src/mat4.c',
+    'src/plane.c',
+    'src/project.c',
+    'src/quat.c',
+    'src/ray.c',
+    'src/sphere.c',
+    'src/vec2.c',
+    'src/vec3.c',
+    'src/vec4.c'
+)
+
+install_subdir('include/cglm', install_dir : get_option('includedir'))
+
+cglm_lib = library('cglm',
+    cglm_src,
+    install : true,
+    dependencies : cglm_deps,
+    c_args : [ build_args, cglm_args ]
+)
+
+cglm_dep = declare_dependency(
+    link_with : cglm_lib,
+    dependencies : cglm_deps,
+    compile_args : cglm_args,
+    include_directories : cglm_inc,
+    version : meson.project_version()
+)
+
+if meson.version().version_compare('>= 0.54.0')
+    meson.override_dependency('cglm', cglm_dep)
+endif
+
+
+pkg = import('pkgconfig')
+
+pkg.generate(
+    name : 'cglm',
+    libraries : cglm_lib,
+    extra_cflags : cglm_args,
+    version : meson.project_version(),
+    url : 'https://github.com/recp/cglm',
+    description : 'OpenGL Mathematics (glm) for C'
+)
+
+
+test_src = files(
+  'test/runner.c',
+  'test/src/test_euler.c',
+  'test/src/test_bezier.c',
+  'test/src/test_cam.c',
+  'test/src/test_struct.c',
+  'test/src/test_clamp.c',
+  'test/src/test_common.c',
+  'test/src/tests.c'
+)
+
+test_exe = executable('tests', 
+    test_src, 
+    dependencies : cglm_dep,
+    c_args : '-DGLM_TESTS_NO_COLORFUL_OUTPUT'
+)
+
+test('cglm.tests', test_exe)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('build_tests', type : 'boolean', value : false, description : 'Build tests')


### PR DESCRIPTION
Building the tests can be put behind an option, it just requires another `meson_options.txt` file in the top-level directory.