### PR TITLE
Added simple swiftpm package file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             path: "./",
             exclude: [
                 "./docs",
-                "./dummySrcForSwift",
+                "./src/swift",
                 "./include",
                 "./test",
                 "./win",
@@ -31,12 +31,11 @@ let package = Package(
             exclude: [
                 "./docs",
                 "./include",
-                "./src",
                 "./test",
                 "./win",
             ],
             sources: [
-                "./dummySrcForSwift",
+                "./src/swift",
             ],
             publicHeadersPath: "./include"
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version:5.2
+
+import PackageDescription
+
+let package = Package(
+    name: "cglm",
+    products: [
+        .library(name: "cglm", type: .static, targets: ["cglmHeader"]),
+        .library(name: "cglmc", targets: ["cglmCompiled"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "cglmCompiled",
+            path: "./",
+            exclude: [
+                "./docs",
+                "./dummySrcForSwift",
+                "./include",
+                "./test",
+                "./win",
+            ],
+            sources: [
+                "./src",
+            ],
+            publicHeadersPath: "./include"
+        ),
+        .target(
+            name: "cglmHeader",
+            path: "./",
+            exclude: [
+                "./docs",
+                "./include",
+                "./src",
+                "./test",
+                "./win",
+            ],
+            sources: [
+                "./dummySrcForSwift",
+            ],
+            publicHeadersPath: "./include"
+        ),
+    ],
+    cLanguageStandard: .c11
+)

--- a/README.md
+++ b/README.md
@@ -212,6 +212,38 @@ cglm_dep = dependency('cglm', fallback : 'cglm', 'cglm_dep')
 executable('exe', 'src/main.c', dependencies : cglm_dep)
 ```
 
+### Swift (Swift Package Manager)
+
+Currently only default build options are supported. Add **cglm** dependency to your project:
+
+```swift
+...
+Package( 
+  ...
+  dependencies: [
+    ...
+    .package(url: "https://github.com/recp/cglm", .branch("master")),
+  ]
+  ...
+)
+```
+
+Now add **cgml** as a dependency to your target. Product choices are:
+- **cglm** for inlined version of the library which can be linked only statically
+- **cglmc** for a compiled version of the library with no linking limitation
+
+```swift
+...
+.target(
+  ...
+  dependencies: [
+    ...
+    .product(name: "cglm", package: "cglm"),
+  ]
+  ...
+)
+...
+```
 
 ### Unix (Autotools)
 

--- a/include/module.modulemap
+++ b/include/module.modulemap
@@ -1,0 +1,14 @@
+module cglm {
+    header "cglm/cglm.h"
+    header "cglm/struct.h"
+    
+    export *
+}
+
+module cglmc {
+    header "cglm/cglm.h"
+    header "cglm/struct.h"
+    header "cglm/call.h"
+    
+    export *
+}

--- a/src/swift/empty.c
+++ b/src/swift/empty.c
@@ -1,0 +1,1 @@
+// This empty file is needed to trick swiftpm to build the header-only version of cglm as swiftpm itself does not support C targets that have no source code files


### PR DESCRIPTION
This PR adds the most simple Package.swift configuration file to enable usage of cglm in swift project.
Unfortunately swiftpm does not support header-only C targets which means this library has to either include empty dummy source for header-based version or build everything. Also using array based API in swift is not very convenient, so it makes sense to include both array based and struct based API.
The config exposes two tagets: 
- cglmc is the "all in one" cglm including inline API, both array based and struct based and the compiled files. Configuration allows usage of this target as static or dynamic library for the client
- cglm is the inline only version that includes both array based and struct based API. In order to force swiftpm to actually build this target the empty.c file is included in dummySrcForSwift folder to avoid "this target is empty" error. This target is available only as static library to give compiler and linker ability to strip unused symbols