### PR TITLE
Fix docs for glm_vec2()

### DIFF
--- a/docs/source/vec2.rst
+++ b/docs/source/vec2.rst
@@ -55,12 +55,12 @@ Functions:
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. c:function:: void glm_vec2(vec4 v4, vec2 dest)
+.. c:function:: void glm_vec2(float \*v, vec2 dest)
 
-    init vec2 using vec3
+    init vec2 using vec3 or vec4
 
     Parameters:
-      | *[in]*  **v3**    vector3
+      | *[in]*  **v**     vector
       | *[out]* **dest**  destination
 
 .. c:function:: void glm_vec2_copy(vec2 a, vec2 dest)


### PR DESCRIPTION
The prototype takes a float *, which can be vec3 or vec4.