### PR TITLE
meson: add 'install' option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ project('cglm', 'c',
 
 cc = meson.get_compiler('c')
 
+cglm_install = get_option('install')
 cglm_deps = cc.find_library('m', required : false)
 
 cglm_args = []
@@ -50,11 +51,9 @@ cglm_src = files(
     'src/vec4.c'
 )
 
-install_subdir('include/cglm', install_dir : get_option('includedir'))
-
 cglm_lib = library('cglm',
     cglm_src,
-    install : true,
+    install : cglm_install,
     dependencies : cglm_deps,
     c_args : [ build_args, cglm_args ]
 )
@@ -71,17 +70,19 @@ if meson.version().version_compare('>= 0.54.0')
     meson.override_dependency('cglm', cglm_dep)
 endif
 
+if cglm_install
+    install_subdir('include/cglm', install_dir : get_option('includedir'))
 
-pkg = import('pkgconfig')
-
-pkg.generate(
-    name : 'cglm',
-    libraries : cglm_lib,
-    extra_cflags : cglm_args,
-    version : meson.project_version(),
-    url : 'https://github.com/recp/cglm',
-    description : 'OpenGL Mathematics (glm) for C'
-)
+    pkg = import('pkgconfig')
+    pkg.generate(
+        name : 'cglm',
+        libraries : cglm_lib,
+        extra_cflags : cglm_args,
+        version : meson.project_version(),
+        url : 'https://github.com/recp/cglm',
+        description : 'OpenGL Mathematics (glm) for C'
+    )
+endif
 
 if get_option('build_tests') == true
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('build_tests', type : 'boolean', value : false, description : 'Build tests')
+option('install', type : 'boolean', value : true, description : 'Include the library, headers, and pkg-config file in the install target')


### PR DESCRIPTION
This is useful for people who want to use cglm as a meson subproject without polluting the main project's install target.