### PR TITLE
Fix fix docs for glm_vec2()

### DIFF
--- a/docs/source/vec2.rst
+++ b/docs/source/vec2.rst
@@ -55,7 +55,7 @@ Functions:
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. c:function:: void glm_vec2(float \*v, vec2 dest)
+.. c:function:: void glm_vec2(float * v, vec2 dest)
 
     init vec2 using vec3 or vec4
 


### PR DESCRIPTION
Remove extra `\` symbol.

Spotted in #167