### PR TITLE
Fix Documentions WARNING for __restrict attribute

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+# needs_sphinx = '3.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -197,3 +197,7 @@ epub_exclude_files = ['search.html']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Options for the C domain ------------------------------------------------
+
+c_id_attributes = ['__restrict']


### PR DESCRIPTION
Add `__restrict` keyword to `c_id_attributes` added in `sphinx 3.0`.

Closes #167