### PR TITLE
Remove CGLM_USE_DEFAULT_EPSILON and use system's float epsilon as default 

### DIFF
--- a/include/cglm/common.h
+++ b/include/cglm/common.h
@@ -42,12 +42,18 @@
 #include "types.h"
 #include "simd/intrin.h"
 
-#ifndef CGLM_USE_DEFAULT_EPSILON
-#  ifndef GLM_FLT_EPSILON
-#    define GLM_FLT_EPSILON 1e-6
+/** CGLM_USE_DEFAULT_EPSILON is removed, to override float epsilon,
+ *  just define GLM_FLT_EPSILON with epsilon value like below
+ *
+ *  #define GLM_FLT_EPSILON 1e-6f
+ */
+
+#ifndef GLM_FLT_EPSILON
+#  ifndef FLT_EPSILON
+#    define GLM_FLT_EPSILON 1e-6f
+#  else
+#    define GLM_FLT_EPSILON FLT_EPSILON
 #  endif
-#else
-#  define GLM_FLT_EPSILON FLT_EPSILON
 #endif
 
 #endif /* cglm_common_h */


### PR DESCRIPTION
Previous:

```C
#ifndef CGLM_USE_DEFAULT_EPSILON
#  ifndef GLM_FLT_EPSILON
#    define GLM_FLT_EPSILON 1e-6
#  endif
#else
#  define GLM_FLT_EPSILON FLT_EPSILON
#endif
```

New:

```C
#ifndef GLM_FLT_EPSILON
#  ifndef FLT_EPSILON
#    define GLM_FLT_EPSILON 1e-6f
#  else
#    define GLM_FLT_EPSILON FLT_EPSILON
#  endif
#endif
```

* To override float epsilon we just need to define GLM_FLT_EPSILON
* CGLM_USE_DEFAULT_EPSILON was redundant, also it forces to override system default epsilon which may not be good idea, because not all systems may support smaller epsilon values

The epsilon value is used in tests but we must use bigger number is some places, because after matrix multiplication, projection... floating errors may occurs which may bigger than epsilon. Probably it will depend on the matrix 