### PR TITLE
Optimizations with FMA

### DIFF
--- a/include/cglm/mat4.h
+++ b/include/cglm/mat4.h
@@ -539,7 +539,9 @@ glm_mat4_scale_p(mat4 m, float s) {
 CGLM_INLINE
 void
 glm_mat4_scale(mat4 m, float s) {
-#if defined( __SSE__ ) || defined( __SSE2__ )
+#ifdef __AVX__
+  glm_mat4_scale_avx(m, s);
+#elif defined( __SSE__ ) || defined( __SSE2__ )
   glm_mat4_scale_sse2(m, s);
 #elif defined(CGLM_NEON_FP)
   glm_mat4_scale_neon(m, s);

--- a/include/cglm/simd/arm.h
+++ b/include/cglm/simd/arm.h
@@ -99,5 +99,21 @@ glmm_fnmadd(float32x4_t a, float32x4_t b, float32x4_t c) {
 #endif
 }
 
+static inline
+float32x4_t
+glmm_fmsub(float32x4_t a, float32x4_t b, float32x4_t c) {
+#if defined(__aarch64__)
+  return vfmsq_f32(c, a, b);
+#else
+  return vmlsq_f32(c, a, b);
+#endif
+}
+
+static inline
+float32x4_t
+glmm_fnmsub(float32x4_t a, float32x4_t b, float32x4_t c) {
+  return vsubq_f32(vdupq_n_f32(0.0f), glmm_fmadd(a, b, c));
+}
+
 #endif
 #endif /* cglm_simd_arm_h */

--- a/include/cglm/simd/arm.h
+++ b/include/cglm/simd/arm.h
@@ -83,9 +83,9 @@ static inline
 float32x4_t
 glmm_fmadd(float32x4_t a, float32x4_t b, float32x4_t c) {
 #if defined(__aarch64__)
-  return vfmaq_f32(a, b, c);
+  return vfmaq_f32(c, a, b);
 #else
-  return vmlaq_f32(a, b, c);
+  return vmlaq_f32(c, a, b);
 #endif
 }
 
@@ -93,9 +93,9 @@ static inline
 float32x4_t
 glmm_fnmadd(float32x4_t a, float32x4_t b, float32x4_t c) {
 #if defined(__aarch64__)
-  return vfmsq_f32(a, b, c);
+  return vfmsq_f32(c, a, b);
 #else
-  return vmlsq_f32(a, b, c);
+  return vmlsq_f32(c, a, b);
 #endif
 }
 

--- a/include/cglm/simd/arm.h
+++ b/include/cglm/simd/arm.h
@@ -79,5 +79,25 @@ glmm_norm_inf(float32x4_t a) {
   return glmm_hmax(glmm_abs(a));
 }
 
+static inline
+float32x4_t
+glmm_fmadd(float32x4_t a, float32x4_t b, float32x4_t c) {
+#if defined(__aarch64__)
+  return vfmaq_f32(a, b, c);
+#else
+  return vmlaq_f32(a, b, c);
+#endif
+}
+
+static inline
+float32x4_t
+glmm_fnmadd(float32x4_t a, float32x4_t b, float32x4_t c) {
+#if defined(__aarch64__)
+  return vfmsq_f32(a, b, c);
+#else
+  return vmlsq_f32(a, b, c);
+#endif
+}
+
 #endif
 #endif /* cglm_simd_arm_h */

--- a/include/cglm/simd/avx/mat4.h
+++ b/include/cglm/simd/avx/mat4.h
@@ -16,6 +16,16 @@
 
 CGLM_INLINE
 void
+glm_mat4_scale_avx(mat4 m, float s) {
+  __m256 y0;
+  y0 = _mm256_set1_ps(s);
+  
+  glmm_store256(m[0], _mm256_mul_ps(y0, glmm_load256(m[0])));
+  glmm_store256(m[2], _mm256_mul_ps(y0, glmm_load256(m[2])));
+}
+
+CGLM_INLINE
+void
 glm_mat4_mul_avx(mat4 m1, mat4 m2, mat4 dest) {
   /* D = R * L (Column-Major) */
 

--- a/include/cglm/simd/sse2/affine.h
+++ b/include/cglm/simd/sse2/affine.h
@@ -22,31 +22,32 @@ glm_mul_sse2(mat4 m1, mat4 m2, mat4 dest) {
   l1 = glmm_load(m1[1]);
   l2 = glmm_load(m1[2]);
   l3 = glmm_load(m1[3]);
-
+  
   r = glmm_load(m2[0]);
   glmm_store(dest[0],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_mul_ps(glmm_shuff1x(r, 2), l2)));
-
+             glmm_fmadd(glmm_shuff1x(r, 0), l0,
+                        glmm_fmadd(glmm_shuff1x(r, 1), l1,
+                                   _mm_mul_ps(glmm_shuff1x(r, 2), l2))));
+  
   r = glmm_load(m2[1]);
   glmm_store(dest[1],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_mul_ps(glmm_shuff1x(r, 2), l2)));
+             glmm_fmadd(glmm_shuff1x(r, 0), l0,
+                        glmm_fmadd(glmm_shuff1x(r, 1), l1,
+                                   _mm_mul_ps(glmm_shuff1x(r, 2), l2))));
 
   r = glmm_load(m2[2]);
   glmm_store(dest[2],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_mul_ps(glmm_shuff1x(r, 2), l2)));
+             glmm_fmadd(glmm_shuff1x(r, 0), l0,
+                        glmm_fmadd(glmm_shuff1x(r, 1), l1,
+                                   _mm_mul_ps(glmm_shuff1x(r, 2), l2))));
 
   r = glmm_load(m2[3]);
   glmm_store(dest[3],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 2), l2),
-                                   _mm_mul_ps(glmm_shuff1x(r, 3), l3))));
+             glmm_fmadd(glmm_shuff1x(r, 0), l0,
+                        glmm_fmadd(glmm_shuff1x(r, 1), l1,
+                                   glmm_fmadd(glmm_shuff1x(r, 2), l2,
+                                              _mm_mul_ps(glmm_shuff1x(r, 3),
+                                                         l3)))));
 }
 
 CGLM_INLINE
@@ -62,21 +63,22 @@ glm_mul_rot_sse2(mat4 m1, mat4 m2, mat4 dest) {
 
   r = glmm_load(m2[0]);
   glmm_store(dest[0],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_mul_ps(glmm_shuff1x(r, 2), l2)));
-
+             glmm_fmadd(glmm_shuff1x(r, 0), l0,
+                        glmm_fmadd(glmm_shuff1x(r, 1), l1,
+                                   _mm_mul_ps(glmm_shuff1x(r, 2), l2))));
+  
   r = glmm_load(m2[1]);
   glmm_store(dest[1],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_mul_ps(glmm_shuff1x(r, 2), l2)));
-
+             glmm_fmadd(glmm_shuff1x(r, 0), l0,
+                        glmm_fmadd(glmm_shuff1x(r, 1), l1,
+                                   _mm_mul_ps(glmm_shuff1x(r, 2), l2))));
+  
+  
   r = glmm_load(m2[2]);
   glmm_store(dest[2],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_mul_ps(glmm_shuff1x(r, 2), l2)));
+             glmm_fmadd(glmm_shuff1x(r, 0), l0,
+                        glmm_fmadd(glmm_shuff1x(r, 1), l1,
+                                   _mm_mul_ps(glmm_shuff1x(r, 2), l2))));
 
   glmm_store(dest[3], l3);
 }
@@ -94,9 +96,9 @@ glm_inv_tr_sse2(mat4 mat) {
 
   _MM_TRANSPOSE4_PS(r0, r1, r2, x1);
 
-  x0 = _mm_add_ps(_mm_mul_ps(r0, glmm_shuff1(r3, 0, 0, 0, 0)),
-                  _mm_mul_ps(r1, glmm_shuff1(r3, 1, 1, 1, 1)));
-  x0 = _mm_add_ps(x0, _mm_mul_ps(r2, glmm_shuff1(r3, 2, 2, 2, 2)));
+  x0 = glmm_fmadd(r0, glmm_shuff1(r3, 0, 0, 0, 0),
+             glmm_fmadd(r1, glmm_shuff1(r3, 1, 1, 1, 1),
+                        _mm_mul_ps(r2, glmm_shuff1(r3, 2, 2, 2, 2))));
   x0 = _mm_xor_ps(x0, _mm_set1_ps(-0.f));
 
   x0 = _mm_add_ps(x0, x1);

--- a/include/cglm/simd/sse2/mat2.h
+++ b/include/cglm/simd/sse2/mat2.h
@@ -26,11 +26,11 @@ glm_mat2_mul_sse2(mat2 m1, mat2 m2, mat2 dest) {
    dest[1][0] = a * g + c * h;
    dest[1][1] = b * g + d * h;
    */
-  x0 = _mm_mul_ps(_mm_movelh_ps(x1, x1), glmm_shuff1(x2, 2, 2, 0, 0));
-  x1 = _mm_mul_ps(_mm_movehl_ps(x1, x1), glmm_shuff1(x2, 3, 3, 1, 1));
-  x1 = _mm_add_ps(x0, x1);
+  x0 = glmm_fmadd(_mm_movelh_ps(x1, x1), glmm_shuff1(x2, 2, 2, 0, 0),
+                  _mm_mul_ps(_mm_movehl_ps(x1, x1),
+                             glmm_shuff1(x2, 3, 3, 1, 1)));
 
-  glmm_store(dest[0], x1);
+  glmm_store(dest[0], x0);
 }
 
 CGLM_INLINE

--- a/include/cglm/simd/sse2/mat3.h
+++ b/include/cglm/simd/sse2/mat3.h
@@ -30,24 +30,17 @@ glm_mat3_mul_sse2(mat3 m1, mat3 m2, mat3 dest) {
   x1 = glmm_shuff2(l0, l1, 1, 0, 3, 3, 0, 3, 2, 0);
   x2 = glmm_shuff2(l1, l2, 0, 0, 3, 2, 0, 2, 1, 0);
 
-  x0 = _mm_add_ps(_mm_mul_ps(glmm_shuff1(l0, 0, 2, 1, 0),
-                             glmm_shuff1(r0, 3, 0, 0, 0)),
-                  _mm_mul_ps(x1, glmm_shuff2(r0, r1, 0, 0, 1, 1, 2, 0, 0, 0)));
-
-  x0 = _mm_add_ps(x0,
-                  _mm_mul_ps(x2, glmm_shuff2(r0, r1, 1, 1, 2, 2, 2, 0, 0, 0)));
+  x0 = glmm_fmadd(glmm_shuff1(l0, 0, 2, 1, 0), glmm_shuff1(r0, 3, 0, 0, 0),
+                  glmm_fmadd(x1, glmm_shuff2(r0, r1, 0, 0, 1, 1, 2, 0, 0, 0),
+                             _mm_mul_ps(x2, glmm_shuff2(r0, r1, 1, 1, 2, 2, 2, 0, 0, 0))));
 
   _mm_storeu_ps(dest[0], x0);
 
-  x0 = _mm_add_ps(_mm_mul_ps(glmm_shuff1(l0, 1, 0, 2, 1),
-                             _mm_shuffle_ps(r0, r1, _MM_SHUFFLE(2, 2, 3, 3))),
-                  _mm_mul_ps(glmm_shuff1(x1, 1, 0, 2, 1),
-                             glmm_shuff1(r1, 3, 3, 0, 0)));
-
-  x0 = _mm_add_ps(x0,
-                  _mm_mul_ps(glmm_shuff1(x2, 1, 0, 2, 1),
-                             _mm_shuffle_ps(r1, r2, _MM_SHUFFLE(0, 0, 1, 1))));
-
+  x0 = glmm_fmadd(glmm_shuff1(l0, 1, 0, 2, 1), _mm_shuffle_ps(r0, r1, _MM_SHUFFLE(2, 2, 3, 3)),
+                  glmm_fmadd(glmm_shuff1(x1, 1, 0, 2, 1), glmm_shuff1(r1, 3, 3, 0, 0),
+                             _mm_mul_ps(glmm_shuff1(x2, 1, 0, 2, 1),
+                                        _mm_shuffle_ps(r1, r2, _MM_SHUFFLE(0, 0, 1, 1)))));
+  
   _mm_storeu_ps(&dest[1][1], x0);
 
   dest[2][2] = m1[0][2] * m2[2][0]

--- a/include/cglm/simd/sse2/mat4.h
+++ b/include/cglm/simd/sse2/mat4.h
@@ -55,47 +55,38 @@ glm_mat4_mul_sse2(mat4 m1, mat4 m2, mat4 dest) {
   l1 = glmm_load(m1[1]);
   l2 = glmm_load(m1[2]);
   l3 = glmm_load(m1[3]);
+  
+#define XX(C)                                                                 \
+                                                                              \
+  r = glmm_load(m2[C]);                                                       \
+  glmm_store(dest[C],                                                         \
+             glmm_fmadd(glmm_shuff1x(r, 0), l0,                               \
+                        glmm_fmadd(glmm_shuff1x(r, 1), l1,                    \
+                                   glmm_fmadd(glmm_shuff1x(r, 2), l2,         \
+                                              _mm_mul_ps(glmm_shuff1x(r, 3),  \
+                                                         l3)))));
 
-  r = glmm_load(m2[0]);
-  glmm_store(dest[0],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 2), l2),
-                                   _mm_mul_ps(glmm_shuff1x(r, 3), l3))));
-  r = glmm_load(m2[1]);
-  glmm_store(dest[1],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 2), l2),
-                                   _mm_mul_ps(glmm_shuff1x(r, 3), l3))));
-  r = glmm_load(m2[2]);
-  glmm_store(dest[2],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 2), l2),
-                                   _mm_mul_ps(glmm_shuff1x(r, 3), l3))));
+  XX(0);
+  XX(1);
+  XX(2);
+  XX(3);
 
-  r = glmm_load(m2[3]);
-  glmm_store(dest[3],
-             _mm_add_ps(_mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 0), l0),
-                                   _mm_mul_ps(glmm_shuff1x(r, 1), l1)),
-                        _mm_add_ps(_mm_mul_ps(glmm_shuff1x(r, 2), l2),
-                                   _mm_mul_ps(glmm_shuff1x(r, 3), l3))));
+#undef XX
 }
 
 CGLM_INLINE
 void
 glm_mat4_mulv_sse2(mat4 m, vec4 v, vec4 dest) {
-  __m128 x0, x1, x2;
-
+  __m128 x0, x1;
+  
   x0 = glmm_load(v);
-  x1 = _mm_add_ps(_mm_mul_ps(glmm_load(m[0]), glmm_shuff1x(x0, 0)),
-                  _mm_mul_ps(glmm_load(m[1]), glmm_shuff1x(x0, 1)));
-
-  x2 = _mm_add_ps(_mm_mul_ps(glmm_load(m[2]), glmm_shuff1x(x0, 2)),
-                  _mm_mul_ps(glmm_load(m[3]), glmm_shuff1x(x0, 3)));
-
-  glmm_store(dest, _mm_add_ps(x1, x2));
+  x1 = glmm_fmadd(glmm_load(m[0]), glmm_shuff1x(x0, 0),
+                  glmm_fmadd(glmm_load(m[1]), glmm_shuff1x(x0, 1),
+                             glmm_fmadd(glmm_load(m[2]), glmm_shuff1x(x0, 2),
+                                        _mm_mul_ps(glmm_load(m[3]),
+                                                   glmm_shuff1x(x0, 3)))));
+  
+  glmm_store(dest, x1);
 }
 
 CGLM_INLINE
@@ -115,20 +106,18 @@ glm_mat4_det_sse2(mat4 mat) {
    t[3] = i * p - m * l;
    t[4] = i * o - m * k;
    */
-  x0 = _mm_sub_ps(_mm_mul_ps(glmm_shuff1(r2, 0, 0, 1, 1),
-                             glmm_shuff1(r3, 2, 3, 2, 3)),
-                  _mm_mul_ps(glmm_shuff1(r3, 0, 0, 1, 1),
-                             glmm_shuff1(r2, 2, 3, 2, 3)));
+  x0 = glmm_fnmadd(glmm_shuff1(r3, 0, 0, 1, 1), glmm_shuff1(r2, 2, 3, 2, 3),
+                   _mm_mul_ps(glmm_shuff1(r2, 0, 0, 1, 1),
+                              glmm_shuff1(r3, 2, 3, 2, 3)));
   /*
    t[0] = k * p - o * l;
    t[0] = k * p - o * l;
    t[5] = i * n - m * j;
    t[5] = i * n - m * j;
    */
-  x1 = _mm_sub_ps(_mm_mul_ps(glmm_shuff1(r2, 0, 0, 2, 2),
-                             glmm_shuff1(r3, 1, 1, 3, 3)),
-                  _mm_mul_ps(glmm_shuff1(r3, 0, 0, 2, 2),
-                             glmm_shuff1(r2, 1, 1, 3, 3)));
+  x1 = glmm_fnmadd(glmm_shuff1(r3, 0, 0, 2, 2), glmm_shuff1(r2, 1, 1, 3, 3),
+                   _mm_mul_ps(glmm_shuff1(r2, 0, 0, 2, 2),
+                              glmm_shuff1(r3, 1, 1, 3, 3)));
 
   /*
      a * (f * t[0] - g * t[1] + h * t[2])
@@ -136,21 +125,16 @@ glm_mat4_det_sse2(mat4 mat) {
    + c * (e * t[1] - f * t[3] + h * t[5])
    - d * (e * t[2] - f * t[4] + g * t[5])
    */
-  x2 = _mm_sub_ps(_mm_mul_ps(glmm_shuff1(r1, 0, 0, 0, 1),
-                             _mm_shuffle_ps(x1, x0, _MM_SHUFFLE(1, 0, 0, 0))),
-                  _mm_mul_ps(glmm_shuff1(r1, 1, 1, 2, 2),
-                             glmm_shuff1(x0, 3, 2, 2, 0)));
-
-  x2 = _mm_add_ps(x2,
-                  _mm_mul_ps(glmm_shuff1(r1, 2, 3, 3, 3),
-                             _mm_shuffle_ps(x0, x1, _MM_SHUFFLE(2, 2, 3, 1))));
+  x2 = glmm_fnmadd(glmm_shuff1(r1, 1, 1, 2, 2), glmm_shuff1(x0, 3, 2, 2, 0),
+                   _mm_mul_ps(glmm_shuff1(r1, 0, 0, 0, 1),
+                              _mm_shuffle_ps(x1, x0, _MM_SHUFFLE(1, 0, 0, 0))));
+  x2 = glmm_fmadd(glmm_shuff1(r1, 2, 3, 3, 3),
+                  _mm_shuffle_ps(x0, x1, _MM_SHUFFLE(2, 2, 3, 1)),
+                  x2);
+  
   x2 = _mm_xor_ps(x2, _mm_set_ps(-0.f, 0.f, -0.f, 0.f));
-
-  x0 = _mm_mul_ps(r0, x2);
-  x0 = _mm_add_ps(x0, glmm_shuff1(x0, 0, 1, 2, 3));
-  x0 = _mm_add_ps(x0, glmm_shuff1(x0, 1, 3, 3, 1));
-
-  return _mm_cvtss_f32(x0);
+  
+  return glmm_hadd(_mm_mul_ps(x2, r0));
 }
 
 CGLM_INLINE
@@ -159,8 +143,11 @@ glm_mat4_inv_fast_sse2(mat4 mat, mat4 dest) {
   __m128 r0, r1, r2, r3,
          v0, v1, v2, v3,
          t0, t1, t2, t3, t4, t5,
-         x0, x1, x2, x3, x4, x5, x6, x7;
-
+         x0, x1, x2, x3, x4, x5, x6, x7, x8, x9;
+  
+  x8 = _mm_set_ps(-0.f, 0.f, -0.f, 0.f);
+  x9 = glmm_shuff1(x8, 2, 1, 2, 1);
+  
   /* 127 <- 0 */
   r0 = glmm_load(mat[0]); /* d c b a */
   r1 = glmm_load(mat[1]); /* h g f e */
@@ -177,8 +164,8 @@ glm_mat4_inv_fast_sse2(mat4 mat, mat4 dest) {
      t1[0] = k * p - o * l;
      t2[0] = g * p - o * h;
      t3[0] = g * l - k * h; */
-  t0 = _mm_sub_ps(_mm_mul_ps(x3, x1), _mm_mul_ps(x2, x0));
-
+  t0 = glmm_fnmadd(x2, x0, _mm_mul_ps(x3, x1));
+  
   x4 = _mm_shuffle_ps(r2, r3, _MM_SHUFFLE(2, 1, 2, 1)); /* o n k j */
   x4 = glmm_shuff1(x4, 0, 2, 2, 2);                     /* j n n n */
   x5 = _mm_shuffle_ps(r2, r1, _MM_SHUFFLE(1, 1, 1, 1)); /* f f j j */
@@ -187,14 +174,14 @@ glm_mat4_inv_fast_sse2(mat4 mat, mat4 dest) {
      t1[1] = j * p - n * l;
      t2[1] = f * p - n * h;
      t3[1] = f * l - j * h; */
-  t1 = _mm_sub_ps(_mm_mul_ps(x5, x1), _mm_mul_ps(x4, x0));
-
+   t1 = glmm_fnmadd(x4, x0, _mm_mul_ps(x5, x1));
+  
   /* t1[2] = j * o - n * k
      t1[2] = j * o - n * k;
      t2[2] = f * o - n * g;
      t3[2] = f * k - j * g; */
-  t2 = _mm_sub_ps(_mm_mul_ps(x5, x2), _mm_mul_ps(x4, x3));
-
+  t2 = glmm_fnmadd(x4, x3, _mm_mul_ps(x5, x2));
+  
   x6 = _mm_shuffle_ps(r2, r1, _MM_SHUFFLE(0, 0, 0, 0)); /* e e i i */
   x7 = glmm_shuff2(r3, r2, 0, 0, 0, 0, 2, 0, 0, 0);     /* i m m m */
 
@@ -202,20 +189,20 @@ glm_mat4_inv_fast_sse2(mat4 mat, mat4 dest) {
      t1[3] = i * p - m * l;
      t2[3] = e * p - m * h;
      t3[3] = e * l - i * h; */
-  t3 = _mm_sub_ps(_mm_mul_ps(x6, x1), _mm_mul_ps(x7, x0));
-
+  t3 = glmm_fnmadd(x7, x0, _mm_mul_ps(x6, x1));
+  
   /* t1[4] = i * o - m * k;
      t1[4] = i * o - m * k;
      t2[4] = e * o - m * g;
      t3[4] = e * k - i * g; */
-  t4 = _mm_sub_ps(_mm_mul_ps(x6, x2), _mm_mul_ps(x7, x3));
-
+  t4 = glmm_fnmadd(x7, x3, _mm_mul_ps(x6, x2));
+  
   /* t1[5] = i * n - m * j;
      t1[5] = i * n - m * j;
      t2[5] = e * n - m * f;
      t3[5] = e * j - i * f; */
-  t5 = _mm_sub_ps(_mm_mul_ps(x6, x4), _mm_mul_ps(x7, x5));
-
+  t5 = glmm_fnmadd(x7, x5, _mm_mul_ps(x6, x4));
+  
   x0 = glmm_shuff2(r1, r0, 0, 0, 0, 0, 2, 2, 2, 0); /* a a a e */
   x1 = glmm_shuff2(r1, r0, 1, 1, 1, 1, 2, 2, 2, 0); /* b b b f */
   x2 = glmm_shuff2(r1, r0, 2, 2, 2, 2, 2, 2, 2, 0); /* c c c g */
@@ -226,50 +213,35 @@ glm_mat4_inv_fast_sse2(mat4 mat, mat4 dest) {
    dest[0][1] =-(b * t1[0] - c * t1[1] + d * t1[2]);
    dest[0][2] =  b * t2[0] - c * t2[1] + d * t2[2];
    dest[0][3] =-(b * t3[0] - c * t3[1] + d * t3[2]); */
-  v0 = _mm_add_ps(_mm_mul_ps(x3, t2),
-                  _mm_sub_ps(_mm_mul_ps(x1, t0),
-                             _mm_mul_ps(x2, t1)));
-  v0 = _mm_xor_ps(v0, _mm_set_ps(-0.f, 0.f, -0.f, 0.f));
+  v0 = _mm_xor_ps(glmm_fmadd(x3, t2, glmm_fnmadd(x2, t1, _mm_mul_ps(x1, t0))), x8);
+  
+  /*
+   dest[2][0] =  e * t1[1] - f * t1[3] + h * t1[5];
+   dest[2][1] =-(a * t1[1] - b * t1[3] + d * t1[5]);
+   dest[2][2] =  a * t2[1] - b * t2[3] + d * t2[5];
+   dest[2][3] =-(a * t3[1] - b * t3[3] + d * t3[5]);*/
+  v2 = _mm_xor_ps(glmm_fmadd(x3, t5, glmm_fnmadd(x1, t3, _mm_mul_ps(x0, t1))), x8);
 
   /*
    dest[1][0] =-(e * t1[0] - g * t1[3] + h * t1[4]);
    dest[1][1] =  a * t1[0] - c * t1[3] + d * t1[4];
    dest[1][2] =-(a * t2[0] - c * t2[3] + d * t2[4]);
    dest[1][3] =  a * t3[0] - c * t3[3] + d * t3[4]; */
-  v1 = _mm_add_ps(_mm_mul_ps(x3, t4),
-                  _mm_sub_ps(_mm_mul_ps(x0, t0),
-                             _mm_mul_ps(x2, t3)));
-  v1 = _mm_xor_ps(v1, _mm_set_ps(0.f, -0.f, 0.f, -0.f));
-
-  /*
-   dest[2][0] =  e * t1[1] - f * t1[3] + h * t1[5];
-   dest[2][1] =-(a * t1[1] - b * t1[3] + d * t1[5]);
-   dest[2][2] =  a * t2[1] - b * t2[3] + d * t2[5];
-   dest[2][3] =-(a * t3[1] - b * t3[3] + d * t3[5]);*/
-  v2 = _mm_add_ps(_mm_mul_ps(x3, t5),
-                  _mm_sub_ps(_mm_mul_ps(x0, t1),
-                             _mm_mul_ps(x1, t3)));
-  v2 = _mm_xor_ps(v2, _mm_set_ps(-0.f, 0.f, -0.f, 0.f));
+  v1 = _mm_xor_ps(glmm_fmadd(x3, t4, glmm_fnmadd(x2, t3, _mm_mul_ps(x0, t0))), x9);
 
   /*
    dest[3][0] =-(e * t1[2] - f * t1[4] + g * t1[5]);
    dest[3][1] =  a * t1[2] - b * t1[4] + c * t1[5];
    dest[3][2] =-(a * t2[2] - b * t2[4] + c * t2[5]);
    dest[3][3] =  a * t3[2] - b * t3[4] + c * t3[5]; */
-  v3 = _mm_add_ps(_mm_mul_ps(x2, t5),
-                  _mm_sub_ps(_mm_mul_ps(x0, t2),
-                             _mm_mul_ps(x1, t4)));
-  v3 = _mm_xor_ps(v3, _mm_set_ps(0.f, -0.f, 0.f, -0.f));
+  v3 = _mm_xor_ps(glmm_fmadd(x2, t5, glmm_fnmadd(x1, t4, _mm_mul_ps(x0, t2))), x9);
 
   /* determinant */
   x0 = _mm_shuffle_ps(v0, v1, _MM_SHUFFLE(0, 0, 0, 0));
   x1 = _mm_shuffle_ps(v2, v3, _MM_SHUFFLE(0, 0, 0, 0));
   x0 = _mm_shuffle_ps(x0, x1, _MM_SHUFFLE(2, 0, 2, 0));
 
-  x0 = _mm_mul_ps(x0, r0);
-  x0 = _mm_add_ps(x0, glmm_shuff1(x0, 0, 1, 2, 3));
-  x0 = _mm_add_ps(x0, glmm_shuff1(x0, 1, 0, 0, 1));
-  x0 = _mm_rcp_ps(x0);
+  x0 = _mm_rcp_ps(glmm_vhadd(_mm_mul_ps(x0, r0)));
 
   glmm_store(dest[0], _mm_mul_ps(v0, x0));
   glmm_store(dest[1], _mm_mul_ps(v1, x0));
@@ -283,8 +255,11 @@ glm_mat4_inv_sse2(mat4 mat, mat4 dest) {
   __m128 r0, r1, r2, r3,
          v0, v1, v2, v3,
          t0, t1, t2, t3, t4, t5,
-         x0, x1, x2, x3, x4, x5, x6, x7;
-
+         x0, x1, x2, x3, x4, x5, x6, x7, x8, x9;
+  
+  x8 = _mm_set_ps(-0.f, 0.f, -0.f, 0.f);
+  x9 = glmm_shuff1(x8, 2, 1, 2, 1);
+  
   /* 127 <- 0 */
   r0 = glmm_load(mat[0]); /* d c b a */
   r1 = glmm_load(mat[1]); /* h g f e */
@@ -301,8 +276,8 @@ glm_mat4_inv_sse2(mat4 mat, mat4 dest) {
      t1[0] = k * p - o * l;
      t2[0] = g * p - o * h;
      t3[0] = g * l - k * h; */
-  t0 = _mm_sub_ps(_mm_mul_ps(x3, x1), _mm_mul_ps(x2, x0));
-
+  t0 = glmm_fnmadd(x2, x0, _mm_mul_ps(x3, x1));
+  
   x4 = _mm_shuffle_ps(r2, r3, _MM_SHUFFLE(2, 1, 2, 1)); /* o n k j */
   x4 = glmm_shuff1(x4, 0, 2, 2, 2);                     /* j n n n */
   x5 = _mm_shuffle_ps(r2, r1, _MM_SHUFFLE(1, 1, 1, 1)); /* f f j j */
@@ -311,14 +286,14 @@ glm_mat4_inv_sse2(mat4 mat, mat4 dest) {
      t1[1] = j * p - n * l;
      t2[1] = f * p - n * h;
      t3[1] = f * l - j * h; */
-  t1 = _mm_sub_ps(_mm_mul_ps(x5, x1), _mm_mul_ps(x4, x0));
-
+   t1 = glmm_fnmadd(x4, x0, _mm_mul_ps(x5, x1));
+  
   /* t1[2] = j * o - n * k
      t1[2] = j * o - n * k;
      t2[2] = f * o - n * g;
      t3[2] = f * k - j * g; */
-  t2 = _mm_sub_ps(_mm_mul_ps(x5, x2), _mm_mul_ps(x4, x3));
-
+  t2 = glmm_fnmadd(x4, x3, _mm_mul_ps(x5, x2));
+  
   x6 = _mm_shuffle_ps(r2, r1, _MM_SHUFFLE(0, 0, 0, 0)); /* e e i i */
   x7 = glmm_shuff2(r3, r2, 0, 0, 0, 0, 2, 0, 0, 0);     /* i m m m */
 
@@ -326,20 +301,20 @@ glm_mat4_inv_sse2(mat4 mat, mat4 dest) {
      t1[3] = i * p - m * l;
      t2[3] = e * p - m * h;
      t3[3] = e * l - i * h; */
-  t3 = _mm_sub_ps(_mm_mul_ps(x6, x1), _mm_mul_ps(x7, x0));
-
+  t3 = glmm_fnmadd(x7, x0, _mm_mul_ps(x6, x1));
+  
   /* t1[4] = i * o - m * k;
      t1[4] = i * o - m * k;
      t2[4] = e * o - m * g;
      t3[4] = e * k - i * g; */
-  t4 = _mm_sub_ps(_mm_mul_ps(x6, x2), _mm_mul_ps(x7, x3));
-
+  t4 = glmm_fnmadd(x7, x3, _mm_mul_ps(x6, x2));
+  
   /* t1[5] = i * n - m * j;
      t1[5] = i * n - m * j;
      t2[5] = e * n - m * f;
      t3[5] = e * j - i * f; */
-  t5 = _mm_sub_ps(_mm_mul_ps(x6, x4), _mm_mul_ps(x7, x5));
-
+  t5 = glmm_fnmadd(x7, x5, _mm_mul_ps(x6, x4));
+  
   x0 = glmm_shuff2(r1, r0, 0, 0, 0, 0, 2, 2, 2, 0); /* a a a e */
   x1 = glmm_shuff2(r1, r0, 1, 1, 1, 1, 2, 2, 2, 0); /* b b b f */
   x2 = glmm_shuff2(r1, r0, 2, 2, 2, 2, 2, 2, 2, 0); /* c c c g */
@@ -350,50 +325,35 @@ glm_mat4_inv_sse2(mat4 mat, mat4 dest) {
    dest[0][1] =-(b * t1[0] - c * t1[1] + d * t1[2]);
    dest[0][2] =  b * t2[0] - c * t2[1] + d * t2[2];
    dest[0][3] =-(b * t3[0] - c * t3[1] + d * t3[2]); */
-  v0 = _mm_add_ps(_mm_mul_ps(x3, t2),
-                  _mm_sub_ps(_mm_mul_ps(x1, t0),
-                             _mm_mul_ps(x2, t1)));
-  v0 = _mm_xor_ps(v0, _mm_set_ps(-0.f, 0.f, -0.f, 0.f));
+  v0 = _mm_xor_ps(glmm_fmadd(x3, t2, glmm_fnmadd(x2, t1, _mm_mul_ps(x1, t0))), x8);
+  
+  /*
+   dest[2][0] =  e * t1[1] - f * t1[3] + h * t1[5];
+   dest[2][1] =-(a * t1[1] - b * t1[3] + d * t1[5]);
+   dest[2][2] =  a * t2[1] - b * t2[3] + d * t2[5];
+   dest[2][3] =-(a * t3[1] - b * t3[3] + d * t3[5]);*/
+  v2 = _mm_xor_ps(glmm_fmadd(x3, t5, glmm_fnmadd(x1, t3, _mm_mul_ps(x0, t1))), x8);
 
   /*
    dest[1][0] =-(e * t1[0] - g * t1[3] + h * t1[4]);
    dest[1][1] =  a * t1[0] - c * t1[3] + d * t1[4];
    dest[1][2] =-(a * t2[0] - c * t2[3] + d * t2[4]);
    dest[1][3] =  a * t3[0] - c * t3[3] + d * t3[4]; */
-  v1 = _mm_add_ps(_mm_mul_ps(x3, t4),
-                  _mm_sub_ps(_mm_mul_ps(x0, t0),
-                             _mm_mul_ps(x2, t3)));
-  v1 = _mm_xor_ps(v1, _mm_set_ps(0.f, -0.f, 0.f, -0.f));
-
-  /*
-   dest[2][0] =  e * t1[1] - f * t1[3] + h * t1[5];
-   dest[2][1] =-(a * t1[1] - b * t1[3] + d * t1[5]);
-   dest[2][2] =  a * t2[1] - b * t2[3] + d * t2[5];
-   dest[2][3] =-(a * t3[1] - b * t3[3] + d * t3[5]);*/
-  v2 = _mm_add_ps(_mm_mul_ps(x3, t5),
-                  _mm_sub_ps(_mm_mul_ps(x0, t1),
-                             _mm_mul_ps(x1, t3)));
-  v2 = _mm_xor_ps(v2, _mm_set_ps(-0.f, 0.f, -0.f, 0.f));
+  v1 = _mm_xor_ps(glmm_fmadd(x3, t4, glmm_fnmadd(x2, t3, _mm_mul_ps(x0, t0))), x9);
 
   /*
    dest[3][0] =-(e * t1[2] - f * t1[4] + g * t1[5]);
    dest[3][1] =  a * t1[2] - b * t1[4] + c * t1[5];
    dest[3][2] =-(a * t2[2] - b * t2[4] + c * t2[5]);
    dest[3][3] =  a * t3[2] - b * t3[4] + c * t3[5]; */
-  v3 = _mm_add_ps(_mm_mul_ps(x2, t5),
-                  _mm_sub_ps(_mm_mul_ps(x0, t2),
-                             _mm_mul_ps(x1, t4)));
-  v3 = _mm_xor_ps(v3, _mm_set_ps(0.f, -0.f, 0.f, -0.f));
+  v3 = _mm_xor_ps(glmm_fmadd(x2, t5, glmm_fnmadd(x1, t4, _mm_mul_ps(x0, t2))), x9);
 
   /* determinant */
   x0 = _mm_shuffle_ps(v0, v1, _MM_SHUFFLE(0, 0, 0, 0));
   x1 = _mm_shuffle_ps(v2, v3, _MM_SHUFFLE(0, 0, 0, 0));
   x0 = _mm_shuffle_ps(x0, x1, _MM_SHUFFLE(2, 0, 2, 0));
 
-  x0 = _mm_mul_ps(x0, r0);
-  x0 = _mm_add_ps(x0, glmm_shuff1(x0, 0, 1, 2, 3));
-  x0 = _mm_add_ps(x0, glmm_shuff1(x0, 1, 0, 0, 1));
-  x0 = _mm_div_ps(_mm_set1_ps(1.0f), x0);
+  x0 = _mm_div_ps(_mm_set1_ps(1.0f), glmm_vhadd(_mm_mul_ps(x0, r0)));
 
   glmm_store(dest[0], _mm_mul_ps(v0, x0));
   glmm_store(dest[1], _mm_mul_ps(v1, x0));

--- a/include/cglm/simd/x86.h
+++ b/include/cglm/simd/x86.h
@@ -197,6 +197,11 @@ glmm_store3(float v[3], __m128 vx) {
   _mm_store_ss(&v[2], glmm_shuff1(vx, 2, 2, 2, 2));
 }
 
+/* enable FMA macro for MSVC? */
+#if !defined(__FMA__) && defined(__AVX2__)
+#  define __FMA__ 1
+#endif
+
 static inline
 __m128
 glmm_fmadd(__m128 a, __m128 b, __m128 c) {

--- a/include/cglm/simd/x86.h
+++ b/include/cglm/simd/x86.h
@@ -50,6 +50,15 @@ glmm_abs(__m128 x) {
 
 static inline
 __m128
+glmm_vhadd(__m128 v) {
+  __m128 x0;
+  x0 = _mm_add_ps(v,  glmm_shuff1(v, 0, 1, 2, 3));
+  x0 = _mm_add_ps(x0, glmm_shuff1(x0, 1, 0, 0, 1));
+  return x0;
+}
+
+static inline
+__m128
 glmm_vhadds(__m128 v) {
 #if defined(__SSE3__)
   __m128 shuf, sums;

--- a/include/cglm/simd/x86.h
+++ b/include/cglm/simd/x86.h
@@ -197,5 +197,25 @@ glmm_store3(float v[3], __m128 vx) {
   _mm_store_ss(&v[2], glmm_shuff1(vx, 2, 2, 2, 2));
 }
 
+static inline
+__m128
+glmm_fmadd(__m128 a, __m128 b, __m128 c) {
+#ifdef __FMA__
+  return  _mm_fmadd_ps(a, b, c);
+#else
+  return _mm_add_ps(c, _mm_mul_ps(a, b));
+#endif
+}
+
+static inline
+__m128
+glmm_fnmadd(__m128 a, __m128 b, __m128 c) {
+#ifdef __FMA__
+  return  _mm_fnmadd_ps(a, b, c);
+#else
+  return _mm_sub_ps(c, _mm_mul_ps(a, b));
+#endif
+}
+
 #endif
 #endif /* cglm_simd_x86_h */

--- a/include/cglm/simd/x86.h
+++ b/include/cglm/simd/x86.h
@@ -201,7 +201,7 @@ static inline
 __m128
 glmm_fmadd(__m128 a, __m128 b, __m128 c) {
 #ifdef __FMA__
-  return  _mm_fmadd_ps(a, b, c);
+  return _mm_fmadd_ps(a, b, c);
 #else
   return _mm_add_ps(c, _mm_mul_ps(a, b));
 #endif
@@ -211,11 +211,74 @@ static inline
 __m128
 glmm_fnmadd(__m128 a, __m128 b, __m128 c) {
 #ifdef __FMA__
-  return  _mm_fnmadd_ps(a, b, c);
+  return _mm_fnmadd_ps(a, b, c);
 #else
   return _mm_sub_ps(c, _mm_mul_ps(a, b));
 #endif
 }
+
+static inline
+__m128
+glmm_fmsub(__m128 a, __m128 b, __m128 c) {
+#ifdef __FMA__
+  return _mm_fmsub_ps(a, b, c);
+#else
+  return _mm_sub_ps(_mm_mul_ps(a, b), c);
+#endif
+}
+
+static inline
+__m128
+glmm_fnmsub(__m128 a, __m128 b, __m128 c) {
+#ifdef __FMA__
+  return _mm_fnmsub_ps(a, b, c);
+#else
+  return _mm_xor_ps(_mm_add_ps(_mm_mul_ps(a, b), c), _mm_set1_ps(-0.0f));
+#endif
+}
+
+#if defined(__AVX__)
+static inline
+__m256
+glmm256_fmadd(__m256 a, __m256 b, __m256 c) {
+#ifdef __FMA__
+  return _mm256_fmadd_ps(a, b, c);
+#else
+  return _mm256_add_ps(c, _mm256_mul_ps(a, b));
+#endif
+}
+
+static inline
+__m256
+glmm256_fnmadd(__m256 a, __m256 b, __m256 c) {
+#ifdef __FMA__
+  return _mm256_fnmadd_ps(a, b, c);
+#else
+  return _mm256_sub_ps(c, _mm256_mul_ps(a, b));
+#endif
+}
+
+static inline
+__m256
+glmm256_fmsub(__m256 a, __m256 b, __m256 c) {
+#ifdef __FMA__
+  return _mm256_fmsub_ps(a, b, c);
+#else
+  return _mm256_sub_ps(_mm256_mul_ps(a, b), c);
+#endif
+}
+
+static inline
+__m256
+glmm256_fnmsub(__m256 a, __m256 b, __m256 c) {
+#ifdef __FMA__
+  return _mm256_fmsub_ps(a, b, c);
+#else
+  return _mm256_xor_ps(_mm256_sub_ps(_mm256_mul_ps(a, b), c),
+                       _mm256_set1_ps(-0.0f));
+#endif
+}
+#endif
 
 #endif
 #endif /* cglm_simd_x86_h */

--- a/include/cglm/vec4.h
+++ b/include/cglm/vec4.h
@@ -590,8 +590,10 @@ glm_vec4_muladd(vec4 a, vec4 b, vec4 dest) {
 CGLM_INLINE
 void
 glm_vec4_muladds(vec4 a, float s, vec4 dest) {
-#if defined(CGLM_SIMD)
+#if defined( __SSE__ ) || defined( __SSE2__ )
   glmm_store(dest, glmm_fmadd(glmm_load(a), _mm_set1_ps(s), glmm_load(dest)));
+#elif defined(CGLM_NEON_FP)
+  glmm_store(dest, glmm_fmadd(glmm_load(a), vdupq_n_f32(s), glmm_load(dest)));
 #else
   dest[0] += a[0] * s;
   dest[1] += a[1] * s;

--- a/include/cglm/vec4.h
+++ b/include/cglm/vec4.h
@@ -568,14 +568,8 @@ glm_vec4_subadd(vec4 a, vec4 b, vec4 dest) {
 CGLM_INLINE
 void
 glm_vec4_muladd(vec4 a, vec4 b, vec4 dest) {
-#if defined( __SSE__ ) || defined( __SSE2__ )
-  glmm_store(dest, _mm_add_ps(glmm_load(dest),
-                              _mm_mul_ps(glmm_load(a),
-                                         glmm_load(b))));
-#elif defined(CGLM_NEON_FP)
-  vst1q_f32(dest, vaddq_f32(vld1q_f32(dest),
-                            vmulq_f32(vld1q_f32(a),
-                                      vld1q_f32(b))));
+#if defined(CGLM_SIMD)
+  glmm_store(dest, glmm_fmadd(glmm_load(a), glmm_load(b), glmm_load(dest)));
 #else
   dest[0] += a[0] * b[0];
   dest[1] += a[1] * b[1];
@@ -596,14 +590,8 @@ glm_vec4_muladd(vec4 a, vec4 b, vec4 dest) {
 CGLM_INLINE
 void
 glm_vec4_muladds(vec4 a, float s, vec4 dest) {
-#if defined( __SSE__ ) || defined( __SSE2__ )
-  glmm_store(dest, _mm_add_ps(glmm_load(dest),
-                              _mm_mul_ps(glmm_load(a),
-                                         _mm_set1_ps(s))));
-#elif defined(CGLM_NEON_FP)
-  vst1q_f32(dest, vaddq_f32(vld1q_f32(dest),
-                            vmulq_f32(vld1q_f32(a),
-                                      vdupq_n_f32(s))));
+#if defined(CGLM_SIMD)
+  glmm_store(dest, glmm_fmadd(glmm_load(a), _mm_set1_ps(s), glmm_load(dest)));
 #else
   dest[0] += a[0] * s;
   dest[1] += a[1] * s;


### PR DESCRIPTION
Optimize SSE operations with FMA instructions to reduce operations and increasee **accuracy**. The gennerated CPU instructions are reduced. All matrix operations are optimized. 

FMA must be enable for this optimizations (with **-mfma** flag on GCC and Clang, MSVC?)

- [x] optimize mat4 SSE operations with FMA
- [x] optimize mat3 SSE operations with FMA
- [x] optimize mat2 SSE operations with FMA
- [x] optimize affine mat SSE operations with FMA
- [x] optimize vec4 muladd and muladds operations with FMA

New **glmm** functions (SSE + NEON):
- `glmm_vhadd()` - broadcast-ed hadd
- `glmm_fmadd(a, b, c)` - fused multiply add 
- `glmm_fnmadd(a, b, c)` - fused negative multiply add
- `glmm_fmsub(a, b, c)` - fused multiply sub 
- `glmm_fnmsub(a, b, c)` - fused negative multiply sub

New **glmm** functions (AVX):
- `glmm256_fmadd(a, b, c)` - fused multiply add AVX
- `glmm256_fnmadd(a, b, c)` - fused negative multiply add AVX
- `glmm256_fmsub(a, b, c)` - fused multiply sub AVX
- `glmm256_fnmsub(a, b, c)` - fused negative multiply sub AVX
- `glm_mat4_scale_avx(mat4 m, float s)` - scale matrix with scalar (if AVX enabled)
