### PR TITLE
fix typo: vec3 -> vec4

### DIFF
--- a/include/cglm/call/vec4.h
+++ b/include/cglm/call/vec4.h
@@ -99,7 +99,7 @@ glmc_vec4_scale(vec4 v, float s, vec4 dest);
 
 CGLM_EXPORT
 void
-glmc_vec4_scale_as(vec3 v, float s, vec3 dest);
+glmc_vec4_scale_as(vec4 v, float s, vec4 dest);
 
 CGLM_EXPORT
 void


### PR DESCRIPTION
Well, I guess it speaks for itself. gcc-11 is now giving a handy warning that indicates parameter mismatches.