### PR TITLE
Update lists of source files in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -102,13 +102,17 @@ if get_option('build_tests') == true
 
 test_src = files(
     'test/runner.c',
-    'test/src/test_euler.c',
     'test/src/test_bezier.c',
     'test/src/test_cam.c',
-    'test/src/test_struct.c',
+    'test/src/test_cam_lh_no.c',
+    'test/src/test_cam_lh_zo.c',
+    'test/src/test_cam_rh_no.c',
+    'test/src/test_cam_rh_zo.c',
     'test/src/test_clamp.c',
     'test/src/test_common.c',
+    'test/src/test_euler.c',
     'test/src/tests.c',
+    'test/src/test_struct.c',
 )
 
 test_exe = executable('tests',

--- a/meson.build
+++ b/meson.build
@@ -56,11 +56,11 @@ cglm_src = files(
     'src/clipspace/persp_lh_no.c',
     'src/clipspace/persp_lh_zo.c',
     'src/clipspace/persp_rh_no.c',
-    'src/clipspace/persp_rh_zo.c'
+    'src/clipspace/persp_rh_zo.c',
     'src/clipspace/view_lh_no.c',
     'src/clipspace/view_lh_zo.c',
-    'src/clipspace/view_rh_no.c'
-    'src/clipspace/view_rh_zo.c'
+    'src/clipspace/view_rh_no.c',
+    'src/clipspace/view_rh_zo.c',
 )
 
 cglm_lib = library('cglm',
@@ -108,7 +108,7 @@ test_src = files(
     'test/src/test_struct.c',
     'test/src/test_clamp.c',
     'test/src/test_common.c',
-    'test/src/tests.c'
+    'test/src/tests.c',
 )
 
 test_exe = executable('tests',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('cglm', 'c',
-    version : '0.8.3', 
+    version : '0.8.3',
     license : 'mit',
     default_options : [
         'c_std=c11',
@@ -111,8 +111,8 @@ test_src = files(
     'test/src/tests.c'
 )
 
-test_exe = executable('tests', 
-    test_src, 
+test_exe = executable('tests',
+    test_src,
     dependencies : cglm_dep,
     c_args : '-DGLM_TESTS_NO_COLORFUL_OUTPUT'
 )


### PR DESCRIPTION
Adds missing files to `meson.build`, and fixes invalid syntax in entries for existing files.

Tested by running:
```
meson setup build -D build_tests=true
ninja -C build test
```