### PR TITLE
Fix vec3_ortho

### DIFF
--- a/docs/source/vec3.rst
+++ b/docs/source/vec3.rst
@@ -474,6 +474,9 @@ Functions documentation
 
     possible orthogonal/perpendicular vector
 
+    References:
+      * `On picking an orthogonal vector (and combing coconuts) <http://lolengine.net/blog/2013/09/21/picking-orthogonal-vector-combing-coconuts>`_
+
     Parameters:
       | *[in]*  **v**     vector
       | *[out]* **dest**  orthogonal/perpendicular vector

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -807,9 +807,10 @@ glm_vec3_minv(vec3 a, vec3 b, vec3 dest) {
 CGLM_INLINE
 void
 glm_vec3_ortho(vec3 v, vec3 dest) {
-  dest[0] = v[1] - v[2];
-  dest[1] = v[2] - v[0];
-  dest[2] = v[0] - v[1];
+  float ignore;
+  float f = modff(fabsf(v[0]) + 0.5f, &ignore);
+  vec3 result = {-v[1], v[0] - f * v[2], f * v[1]};
+  glm_vec3_copy(result, dest);
 }
 
 /*!

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -808,8 +808,8 @@ CGLM_INLINE
 void
 glm_vec3_ortho(vec3 v, vec3 dest) {
   float ignore;
-  float f = modff(fabsf(v[0]) + 0.5f, &ignore);
-  vec3 result = {-v[1], v[0] - f * v[2], f * v[1]};
+  float f      = modff(fabsf(v[0]) + 0.5f, &ignore);
+  vec3  result = {-v[1], v[0] - f * v[2], f * v[1]};
   glm_vec3_copy(result, dest);
 }
 

--- a/test/runner.c
+++ b/test/runner.c
@@ -79,22 +79,20 @@ main(int argc, const char * argv[]) {
 
   if (failed == 0) {
     fprintf(stderr,
-            BOLDGREEN "\n  All tests are passed " FINAL_TEXT "\n" RESET);
+            BOLDGREEN "\n  All tests passed " FINAL_TEXT "\n" RESET);
   }
 
   fprintf(stderr,
           CYAN "\ncglm test results (%0.2fs):\n" RESET
           "--------------------------\n"
 
-          MAGENTA "%d" RESET " tests are runned, "
-          GREEN   "%d" RESET " %s passed, "
-          RED     "%d" RESET " %s failed\n\n" RESET,
+          MAGENTA "%d" RESET " tests ran, "
+          GREEN   "%d" RESET " passed, "
+          RED     "%d" RESET " failed\n\n" RESET,
           total,
           count,
           passed,
-          passed > 1 ? "are" : "is",
-          failed,
-          failed > 1 ? "are" : "is");
+          failed);
 
   return failed;
 }

--- a/test/src/test_vec3.h
+++ b/test/src/test_vec3.h
@@ -1123,8 +1123,8 @@ TEST_IMPL(GLM_PREFIX, vec3_minv) {
 }
 
 TEST_IMPL(GLM_PREFIX, vec3_ortho) {
-  vec3  v1, v2, v3;
-  vec3  v5, v6, v7;
+  vec3  v1, v2, v3, v4 = {1.f, 1.f, 1.f};
+  vec3  v5, v6, v7, v8;
   float a;
 
   test_rand_vec3(v1);
@@ -1134,6 +1134,7 @@ TEST_IMPL(GLM_PREFIX, vec3_ortho) {
   GLM(vec3_ortho)(v1, v5);
   GLM(vec3_ortho)(v2, v6);
   GLM(vec3_ortho)(v3, v7);
+  GLM(vec3_ortho)(v4, v8);
   
   a = glm_vec3_angle(v1, v5);
   ASSERT(!isinf(a))
@@ -1146,6 +1147,13 @@ TEST_IMPL(GLM_PREFIX, vec3_ortho) {
   ASSERT(test_eq(a, GLM_PI_2f))
   
   a = glm_vec3_angle(v3, v7);
+  ASSERT(!isinf(a))
+  ASSERT(!isnan(a))
+  ASSERT(test_eq(a, GLM_PI_2f))
+
+  a = glm_vec3_angle(v4, v8);
+  printf("(%f, %f, %f)\n", v4[0], v4[1], v4[2]);
+  printf("(%f, %f, %f)\n", v8[0], v8[1], v8[2]);
   ASSERT(!isinf(a))
   ASSERT(!isnan(a))
   ASSERT(test_eq(a, GLM_PI_2f))

--- a/test/src/test_vec3.h
+++ b/test/src/test_vec3.h
@@ -1152,8 +1152,6 @@ TEST_IMPL(GLM_PREFIX, vec3_ortho) {
   ASSERT(test_eq(a, GLM_PI_2f))
 
   a = glm_vec3_angle(v4, v8);
-  printf("(%f, %f, %f)\n", v4[0], v4[1], v4[2]);
-  printf("(%f, %f, %f)\n", v8[0], v8[1], v8[2]);
   ASSERT(!isinf(a))
   ASSERT(!isnan(a))
   ASSERT(test_eq(a, GLM_PI_2f))


### PR DESCRIPTION
* Fix `glm_vec3_ortho` to work with all `vec3` inputs
  - Previous algorithm results in 0-vector for inputs like `<1, 1, 1>`
* Update documentation with algorithm reference link