### PR TITLE
Fix cross product when an operand is also dest

### DIFF
--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -578,10 +578,12 @@ glm_vec3_normalize_to(vec3 v, vec3 dest) {
 CGLM_INLINE
 void
 glm_vec3_cross(vec3 a, vec3 b, vec3 dest) {
+  vec3 c;
   /* (u2.v3 - u3.v2, u3.v1 - u1.v3, u1.v2 - u2.v1) */
-  dest[0] = a[1] * b[2] - a[2] * b[1];
-  dest[1] = a[2] * b[0] - a[0] * b[2];
-  dest[2] = a[0] * b[1] - a[1] * b[0];
+  c[0] = a[1] * b[2] - a[2] * b[1];
+  c[1] = a[2] * b[0] - a[0] * b[2];
+  c[2] = a[0] * b[1] - a[1] * b[0];
+  glm_vec3_copy(c, dest);
 }
 
 /*!


### PR DESCRIPTION
Fix cross product function to work when `dest` is one of the operands by
storing a result in a temporary and then copying it to `dest`.

Fix for #208