### PR TITLE
Note that radians is expected in glm_perspective()

### DIFF
--- a/docs/source/cam.rst
+++ b/docs/source/cam.rst
@@ -140,7 +140,7 @@ Functions documentation
     | set up perspective projection matrix
 
     Parameters:
-      | *[in]*  **fovy**    field of view angle
+      | *[in]*  **fovy**    field of view angle (in radians)
       | *[in]*  **aspect**  aspect ratio ( width / height )
       | *[in]*  **nearVal** near clipping plane
       | *[in]*  **farVal**  far clipping planes


### PR DESCRIPTION
The `fovy` parameter is expected in radians, which isn't mentioned anywhere in the docs. Causes unnecessary confusion. Might as well point it out.