### PR TITLE
win: fix shared library name and destination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,12 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
                               VERSION ${PROJECT_VERSION} 
                             SOVERSION ${PROJECT_VERSION_MAJOR})
 
+if(WIN32)
+  # Because SOVERSION has no effect to file naming on Windows
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+    RUNTIME_OUTPUT_NAME ${PROJECT_NAME}-${PROJECT_VERSION_MAJOR})
+endif()
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC 
         $<INSTALL_INTERFACE:include>    
@@ -122,7 +128,7 @@ install(TARGETS ${PROJECT_NAME}
         EXPORT  ${PROJECT_NAME}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         PATTERN ".*" EXCLUDE)


### PR DESCRIPTION
Currently we use this [patch](https://github.com/msys2/MINGW-packages/commit/cf919652c73470871e02b6073da6e3b6d07ce910#diff-2b935e91698a2d851142d8fd01a4dd82b8eb51997fa3e8162d5025feba0fb3da) to make `Autotools` compatible output when [migrate](https://github.com/msys2/MINGW-packages/pull/9744) to `CMake` on `Windows` in `MSYS2` [package](https://packages.msys2.org/base/mingw-w64-cglm).