### PR TITLE
Add complex routines to `vec2-ext`

### DIFF
--- a/include/cglm/call/vec2.h
+++ b/include/cglm/call/vec2.h
@@ -149,6 +149,18 @@ CGLM_EXPORT
 void
 glmc_vec2_lerp(vec2 from, vec2 to, float t, vec2 dest);
 
+CGLM_EXPORT
+void
+glmc_vec2_complex_mul(vec2 a, vec2 b, vec2 dest);
+
+CGLM_EXPORT
+void
+glmc_vec2_complex_div(vec2 a, vec2 b, vec2 dest);
+
+CGLM_EXPORT
+void
+glmc_vec2_complex_conjugate(vec2 a, vec2 dest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/cglm/struct/vec2-ext.h
+++ b/include/cglm/struct/vec2-ext.h
@@ -195,4 +195,45 @@ glms_vec2_sqrt(vec2s v) {
   return r;
 }
 
+/*!
+ * @brief treat vectors as complex numbers and multiply them as such.
+ *
+ * @param[in]  a    left number
+ * @param[in]  b    right number
+ * @param[out] dest destination number
+ */
+CGLM_INLINE
+vec2s
+glms_vec2_complex_mul(vec2s a, vec2s b, vec2s dest) {
+  glm_vec2_complex_mul(a.raw, b.raw, dest.raw);
+  return dest;
+}
+
+/*!
+ * @brief treat vectors as complex numbers and divide them as such.
+ *
+ * @param[in]  a    left number (numerator)
+ * @param[in]  b    right number (denominator)
+ * @param[out] dest destination number
+ */
+CGLM_INLINE
+vec2s
+glms_vec2_complex_div(vec2s a, vec2s b, vec2s dest) {
+  glm_vec2_complex_div(a.raw, b.raw, dest.raw);
+  return dest;
+}
+
+/*!
+ * @brief treat the vector as a complex number and conjugate it as such.
+ *
+ * @param[in]  a    the number
+ * @param[out] dest destination number
+ */
+CGLM_INLINE
+vec2s
+glms_vec2_complex_conjugate(vec2s a, vec2s dest) {
+  glm_vec2_complex_conjugate(a.raw, dest.raw);
+  return dest;
+}
+
 #endif /* cglms_vec2s_ext_h */

--- a/include/cglm/vec2-ext.h
+++ b/include/cglm/vec2-ext.h
@@ -197,6 +197,7 @@ glm_vec2_sqrt(vec2 v, vec2 dest) {
  * @param[out] dest destination number
  */
 CGLM_INLINE
+void
 glm_vec2_complex_mul(vec2 a, vec2 b, vec2 dest) {
   float tr, ti;
   tr = a[0] * b[0] - a[1] * b[1];
@@ -213,6 +214,7 @@ glm_vec2_complex_mul(vec2 a, vec2 b, vec2 dest) {
  * @param[out] dest destination number
  */
 CGLM_INLINE
+void
 glm_vec2_complex_div(vec2 a, vec2 b, vec2 dest) {
   float tr, ti;
   float const ibnorm2 = 1.0f / (b[0] * b[0] + b[1] * b[1]);
@@ -229,6 +231,7 @@ glm_vec2_complex_div(vec2 a, vec2 b, vec2 dest) {
  * @param[out] dest destination number
  */
 CGLM_INLINE
+void
 glm_vec2_complex_conjugate(vec2 a, vec2 dest) {
   dest[0] =  a[0]
   dest[1] = -a[1];

--- a/include/cglm/vec2-ext.h
+++ b/include/cglm/vec2-ext.h
@@ -218,8 +218,8 @@ void
 glm_vec2_complex_div(vec2 a, vec2 b, vec2 dest) {
   float tr, ti;
   float const ibnorm2 = 1.0f / (b[0] * b[0] + b[1] * b[1]);
-  tr = ibnorm * (a[0] * b[0] + a[1] * b[1])
-  ti = ibnorm * (a[1] * b[0] - a[0] * b[1])
+  tr = ibnorm2 * (a[0] * b[0] + a[1] * b[1]);
+  ti = ibnorm2 * (a[1] * b[0] - a[0] * b[1]);
   dest[0] = tr;
   dest[1] = ti;
 }
@@ -233,7 +233,7 @@ glm_vec2_complex_div(vec2 a, vec2 b, vec2 dest) {
 CGLM_INLINE
 void
 glm_vec2_complex_conjugate(vec2 a, vec2 dest) {
-  dest[0] =  a[0]
+  dest[0] =  a[0];
   dest[1] = -a[1];
 }
 

--- a/include/cglm/vec2-ext.h
+++ b/include/cglm/vec2-ext.h
@@ -20,6 +20,9 @@
    CGLM_INLINE bool  glm_vec2_isvalid(vec2 v);
    CGLM_INLINE void  glm_vec2_sign(vec2 v, vec2 dest);
    CGLM_INLINE void  glm_vec2_sqrt(vec2 v, vec2 dest);
+   CGLM_INLINE void  glm_vec2_complex_mul(vec2 a, vec2 b, vec2 dest)
+   CGLM_INLINE void  glm_vec2_complex_div(vec2 a, vec2 b, vec2 dest)
+   CGLM_INLINE void  glm_vec2_complex_conjugate(vec2 a, vec2 dest)
  */
 
 #ifndef cglm_vec2_ext_h
@@ -185,5 +188,51 @@ glm_vec2_sqrt(vec2 v, vec2 dest) {
   dest[0] = sqrtf(v[0]);
   dest[1] = sqrtf(v[1]);
 }
+
+/*!
+ * @brief treat vectors as complex numbers and multiply them as such.
+ *
+ * @param[in]  a    left number
+ * @param[in]  b    right number
+ * @param[out] dest destination number
+ */
+CGLM_INLINE
+glm_vec2_complex_mul(vec2 a, vec2 b, vec2 dest) {
+  float tr, ti;
+  tr = a[0] * b[0] - a[1] * b[1];
+  ti = a[0] * b[1] + a[1] * b[0];
+  dest[0] = tr;
+  dest[1] = ti;
+}
+
+/*!
+ * @brief treat vectors as complex numbers and divide them as such.
+ *
+ * @param[in]  a    left number (numerator)
+ * @param[in]  b    right number (denominator)
+ * @param[out] dest destination number
+ */
+CGLM_INLINE
+glm_vec2_complex_div(vec2 a, vec2 b, vec2 dest) {
+  float tr, ti;
+  float const ibnorm2 = 1.0f / (b[0] * b[0] + b[1] * b[1]);
+  tr = ibnorm * (a[0] * b[0] + a[1] * b[1])
+  ti = ibnorm * (a[1] * b[0] - a[0] * b[1])
+  dest[0] = tr;
+  dest[1] = ti;
+}
+
+/*!
+ * @brief treat the vector as a complex number and conjugate it as such.
+ *
+ * @param[in]  a    the number
+ * @param[out] dest destination number
+ */
+CGLM_INLINE
+glm_vec2_complex_conjugate(vec2 a, vec2 dest) {
+  dest[0] =  a[0]
+  dest[1] = -a[1];
+}
+
 
 #endif /* cglm_vec2_ext_h */

--- a/src/vec2.c
+++ b/src/vec2.c
@@ -211,3 +211,21 @@ void
 glmc_vec2_lerp(vec2 from, vec2 to, float t, vec2 dest) {
   glm_vec2_lerp(from, to, t, dest);
 }
+
+CGLM_EXPORT
+void
+glmc_vec2_complex_mul(vec2 a, vec2 b, vec2 dest) {
+  glm_vec2_complex_mul(a, b, dest);
+}
+
+CGLM_EXPORT
+void
+glmc_vec2_complex_div(vec2 a, vec2 b, vec2 dest) {
+  glm_vec2_complex_div(a, b, dest);
+}
+
+CGLM_EXPORT
+void
+glmc_vec2_complex_conjugate(vec2 a, vec2 dest) {
+  glm_vec2_complex_conjugate(a, dest);
+}

--- a/test/src/test_vec2.h
+++ b/test/src/test_vec2.h
@@ -594,3 +594,32 @@ TEST_IMPL(GLM_PREFIX, vec2_lerp) {
 
   TEST_SUCCESS
 }
+
+TEST_IMPL(GLM_PREFIX, vec2_complex_mul) {
+  vec2 v1 = { 3.0f,  5.0f },
+       v2 = { 7.0f, 11.0f },
+       v3 = { cosf(M_PI/4.0f), sinf(M_PI/4.0f) };
+
+  GLM(vec2_complex_mul)(v1, v2, v2);
+  ASSERTIFY(test_assert_vec2_eq(v2, (vec2){ -34, 68 }))
+
+  GLM(vec2_complex_mul)(v3, v3, v3);
+  ASSERTIFY(test_assert_vec2_eq(v3, (vec2){ 0.0f, 1.0f }))
+
+  TEST_SUCCESS
+}
+
+TEST_IMPL(GLM_PREFIX, vec2_complex_div) {
+  vec2 v1 = { -34.0f,  68.0f },
+       v2 = {   3.0f,   5.0f },
+       v3 = { cosf(M_PI/4.0f),  sinf(M_PI/4.0f) },
+       v4 = { cosf(M_PI/4.0f), -sinf(M_PI/4.0f) };
+  
+  GLM(vec2_complex_div)(v1, v2, v2);
+  ASSERTIFY(test_assert_vec2_eq(v2, (vec2){ 7.0f, 11.0f }))
+
+  GLM(vec2_complex_div)(v3, v4, v4);
+  ASSERTIFY(test_assert_vec2_eq(v4, (vec2){ 0.0f, 1.0f }))
+
+  TEST_SUCCESS
+}

--- a/test/tests.h
+++ b/test/tests.h
@@ -382,6 +382,8 @@ TEST_DECLARE(glm_vec2_maxv)
 TEST_DECLARE(glm_vec2_minv)
 TEST_DECLARE(glm_vec2_clamp)
 TEST_DECLARE(glm_vec2_lerp)
+TEST_DECLARE(glm_vec2_complex_mul)
+TEST_DECLARE(glm_vec2_complex_div)
 
 
 TEST_DECLARE(glmc_vec2)
@@ -418,6 +420,8 @@ TEST_DECLARE(glmc_vec2_maxv)
 TEST_DECLARE(glmc_vec2_minv)
 TEST_DECLARE(glmc_vec2_clamp)
 TEST_DECLARE(glmc_vec2_lerp)
+TEST_DECLARE(glmc_vec2_complex_mul)
+TEST_DECLARE(glmc_vec2_complex_div)
 
 /* vec3 */
 TEST_DECLARE(MACRO_GLM_VEC3_ONE_INIT)
@@ -1112,6 +1116,8 @@ TEST_LIST {
   TEST_ENTRY(glm_vec2_minv)
   TEST_ENTRY(glm_vec2_clamp)
   TEST_ENTRY(glm_vec2_lerp)
+  TEST_ENTRY(glm_vec2_complex_mul)
+  TEST_ENTRY(glm_vec2_complex_div)
 
   TEST_ENTRY(glmc_vec2)
   TEST_ENTRY(glmc_vec2_copy)
@@ -1147,6 +1153,8 @@ TEST_LIST {
   TEST_ENTRY(glmc_vec2_minv)
   TEST_ENTRY(glmc_vec2_clamp)
   TEST_ENTRY(glmc_vec2_lerp)
+  TEST_ENTRY(glmc_vec2_complex_mul)
+  TEST_ENTRY(glmc_vec2_complex_div)
 
   /* vec3 */
   /* Macros */


### PR DESCRIPTION
Related discussion: #227 

In the end only 3 new functions are introduced for multiplication, division, and conjugation—hence why I don't think a separate `complex` type is necessary.

I've tried my best to add tests, and while they seem to work, I had to hack it together a bit since I didn't see any other `vec2-ext` functions being tested and I had to do improvisations of sorts.