### PR TITLE
set PACKAGE_VERSION so it gets substituted in cglm.pc.in by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix ${CMAKE_INSTALL_PREFIX})
 set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(PACKAGE_VERSION "${PROJECT_VERSION}")
 configure_file(${CMAKE_CURRENT_LIST_DIR}/cglm.pc.in ${CMAKE_BINARY_DIR}/cglm.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/cglm.pc


### PR DESCRIPTION
Hello,

I noticed that the installed `cglm.pc.in` file generated by cmake ends up with a bogus line `Version:`: the `PACKAGE_VERSION` is empty!  It was probably forgot in #188.

With this patch applied, the pc file has the correct Version line.