### PR TITLE
Fix a bug in glm_lookat_lh

### DIFF
--- a/include/cglm/clipspace/view_lh.h
+++ b/include/cglm/clipspace/view_lh.h
@@ -38,7 +38,7 @@ glm_lookat_lh(vec3 eye, vec3 center, vec3 up, mat4 dest) {
   glm_vec3_normalize(f);
 
   glm_vec3_crossn(up, f, s);
-  glm_vec3_cross(s, f, u);
+  glm_vec3_cross(f, s, u);
 
   dest[0][0] = s[0];
   dest[0][1] = u[0];

--- a/include/cglm/clipspace/view_lh.h
+++ b/include/cglm/clipspace/view_lh.h
@@ -37,7 +37,7 @@ glm_lookat_lh(vec3 eye, vec3 center, vec3 up, mat4 dest) {
   glm_vec3_sub(center, eye, f);
   glm_vec3_normalize(f);
 
-  glm_vec3_crossn(f, up, s);
+  glm_vec3_crossn(up, f, s);
   glm_vec3_cross(s, f, u);
 
   dest[0][0] = s[0];


### PR DESCRIPTION
I've noticed that the `glm_lookat_lh` produces incorrect results (X axis being negated) which cause the winding order of the triangles to be inversed. By looking into the code, I've noticed that in the normalized cross product between `up` and `f`, as well as the cross product of `f` and `s` have their arguments in the opposite order.

Both glm:
https://github.com/g-truc/glm/blob/b3f87720261d623986f164b2a7f6a0a938430271/glm/ext/matrix_transform.inl#L125-L126
And DirectXMath:
https://github.com/microsoft/DirectXMath/blob/main/Inc/DirectXMathMatrix.inl#L2221-L2224
Show the correct way to perform these cross products in a Left-Hand Coordinate system.