### PR TITLE
Fix grammatical errors in docs index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,13 +6,14 @@
 cglm Documentation
 ================================
 
-**cglm** is optimized 3D math library written in C99 (compatible with C89).
-It is similar to original **glm** library except this is mainly for **C**
+**cglm** is an optimized 3D math library written in C99 (compatible with C89).
+It is similar to the original **glm** library, except **cglm** is mainly for
+**C**.
 
-This library stores matrices as column-major order but in the future row-major
-is considered to be supported as optional.
+**cglm** stores matrices as column-major order but in the future row-major is
+considered to be supported as optional.
 
-Also currently only **float** type is supported for most operations.
+Currently only **float** type is supported for most operations.
 
 .. toctree::
    :maxdepth: 2
@@ -46,8 +47,8 @@ Also currently only **float** type is supported for most operations.
 
    troubleshooting
 
-Indices and tables
-==================
+Indices and Tables:
+===================
 
 * :ref:`genindex`
 * :ref:`modindex`


### PR DESCRIPTION
Fixed a few grammatical errors in the index page of the docs. 

New docs in this pull request:
![cglm_docs_new](https://user-images.githubusercontent.com/60847556/167315439-a77057fd-b4ad-4cd7-b079-0b65616efd1c.png)

Current docs:
![cglm_docs_old](https://user-images.githubusercontent.com/60847556/167315445-b0912a1b-0280-4c86-8356-c320a310f23e.png)

