### PR TITLE
Added missing include in io.h which adds GLM_MAX macro

### DIFF
--- a/include/cglm/io.h
+++ b/include/cglm/io.h
@@ -39,6 +39,7 @@
    || defined(CGLM_NO_PRINTS_NOOP)
 
 #include "common.h"
+#include "util.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Macro GLM_MAX is used in io.h but the header-file which defines it is not included. This PR fixes that. Example of code which does not compile:
```
#define CGLM_DEFINE_PRINTS
#include "cglm/io.h"
#include "cglm/mat3.h"
#include <stdio.h>

int main(void) {
  mat3 x = GLM_MAT3_IDENTITY_INIT;
  glm_mat3_print(x, stdout);
  return 0;
}
```

Compile command:
```
clang -I <path-to-cglm-includes> <path-to-libcglm.a> main.c
```

Note that including the missing header file in the main file is extra-brittle because `clang-format -i main.c` will move `util.h` below `io.h`.
