### PR TITLE
fix: simplified pkgconfig generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.8.2)
-project(cglm VERSION 0.8.6 LANGUAGES C)
+project(cglm
+  VERSION 0.8.6
+  HOMEPAGE_URL https://github.com/recp/cglm
+  DESCRIPTION "OpenGL Mathematics (glm) for C"
+  LANGUAGES C
+)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED YES)
@@ -152,21 +157,7 @@ install(EXPORT      ${PROJECT_NAME}
         NAMESPACE   ${PROJECT_NAME}::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
-set(PACKAGE_NAME ${PROJECT_NAME})
-set(prefix ${CMAKE_INSTALL_PREFIX})
-set(exec_prefix ${CMAKE_INSTALL_PREFIX})
-if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
-  set(includedir "${CMAKE_INSTALL_INCLUDEDIR}")
-else()
-  set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-endif()
-if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
-  set(libdir "${CMAKE_INSTALL_LIBDIR}")
-else()
-  set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
-endif()
-set(PACKAGE_VERSION "${PROJECT_VERSION}")
-configure_file(${CMAKE_CURRENT_LIST_DIR}/cglm.pc.in ${CMAKE_BINARY_DIR}/cglm.pc @ONLY)
+configure_file(cglm.pc.in cglm.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/cglm.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/cglm.pc.in
+++ b/cglm.pc.in
@@ -1,11 +1,11 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix="${prefix}"
+libdir="${exec_prefix}/lib"
+includedir="${prefix}/include"
 
-Name: @PACKAGE_NAME@
-Description: OpenGL Mathematics (glm) for C
-URL: https://github.com/recp/cglm
-Version: @PACKAGE_VERSION@
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lcglm @LIBS@


### PR DESCRIPTION
Currently the packages cglm on NixOS has incorrect paths in `cglm.pc`:

```
$ nix build github:NixOS/nixpkgs/nixos-22.05#cglm
$ cat result/lib/pkgconfig/cglm.pc 
prefix=/nix/store/947f06p7bkalcx0m26zascbmsmi5ymdc-cglm-0.8.5
exec_prefix=/nix/store/947f06p7bkalcx0m26zascbmsmi5ymdc-cglm-0.8.5
libdir=${prefix}//nix/store/947f06p7bkalcx0m26zascbmsmi5ymdc-cglm-0.8.5/lib
includedir=${prefix}//nix/store/947f06p7bkalcx0m26zascbmsmi5ymdc-cglm-0.8.5/include

Name: cglm
Description: OpenGL Mathematics (glm) for C
URL: https://github.com/recp/cglm
Version: 0.8.5
Cflags: -I${includedir}
Libs: -L${libdir} -lcglm 
```

There have been made 2 fixes in parallel in NixOS (https://github.com/NixOS/nixpkgs/pull/181875 and https://github.com/NixOS/nixpkgs/pull/190982). It seemed best to fix this upstream by aligning the `cglm.pc.in` more with other CMake packages.

The output now resembles the output in most packages and aligns with the examples I found online (https://www.scivision.dev/cmake-generate-pkg-config/).

Alternatively `CMAKE_INSTALL_FULL_*DIR` could be used.

I'll ask @Artturin if he could have a look at this PR before asking for a review from any of the maintainers of cglm.