### PR TITLE
test_clamp: use glm_eq for floating point comparison

### DIFF
--- a/test/src/test_clamp.c
+++ b/test/src/test_clamp.c
@@ -18,14 +18,14 @@ TEST_IMPL(clamp) {
   glm_vec3_clamp(v3, 0.0, 1.0);
   glm_vec4_clamp(v4, 1.5, 3.0);
 
-  ASSERT(v3[0] == 1.0f)
-  ASSERT(v3[1] == 0.4f)
-  ASSERT(v3[2] == 1.0f)
+  ASSERT(glm_eq(v3[0], 1.0f))
+  ASSERT(glm_eq(v3[1], 0.4f))
+  ASSERT(glm_eq(v3[2], 1.0f))
 
-  ASSERT(v4[0] == 3.0f)
-  ASSERT(v4[1] == 2.3f)
-  ASSERT(v4[2] == 1.5f)
-  ASSERT(v4[3] == 1.5f)
+  ASSERT(glm_eq(v4[0], 3.0f))
+  ASSERT(glm_eq(v4[1], 2.3f))
+  ASSERT(glm_eq(v4[2], 1.5f))
+  ASSERT(glm_eq(v4[3], 1.5f))
   
   TEST_SUCCESS
 }


### PR DESCRIPTION
Fixes #266

The test was failing later, even after ac9461778c8dbf5de3e04cd12b39f55228fa382c

```
assert fail in ../test/src/test_clamp.c on line 22 :  ASSERT(v3[1] == 0.4f)
```

The package pipeline is now [green](https://gitlab.alpinelinux.org/bl4ckb0ne/aports/-/pipelines/146086)