### PR TITLE
Fix missing abs declaration on Emscripten

### DIFF
--- a/include/cglm/common.h
+++ b/include/cglm/common.h
@@ -18,6 +18,9 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#ifdef __EMSCRIPTEN__
+#include <stdlib.h>
+#endif
 #include <math.h>
 #include <float.h>
 #include <stdbool.h>


### PR DESCRIPTION
When building cglm for Emscripten the following error happen:
```
In file included from C:/Users/kiv/Projects/cglm/src/frustum.c:8:
In file included from C:/Users/kiv/Projects/cglm/src/../include/cglm/cglm.h:15:
C:/Users/kiv/Projects/cglm/src/../include/cglm/ivec2.h:252:13: error: call to undeclared library function 'abs' with type 'int (int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  dest[0] = abs(v[0]);
            ^
C:/Users/kiv/Projects/cglm/src/../include/cglm/ivec2.h:252:13: note: include the header <stdlib.h> or explicitly provide a declaration for 'abs'
1 error generated.
```
This pull request fixes this issue.