### PR TITLE
Switch CMAKE_BINARY_DIR to CMAKE_CURRENT_BINARY_DIR for cmake.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,5 +159,5 @@ install(EXPORT      ${PROJECT_NAME}
 
 configure_file(cglm.pc.in cglm.pc @ONLY)
 
-install(FILES ${CMAKE_BINARY_DIR}/cglm.pc
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cglm.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
While attempting to deploy a Qt project that depends on CGLM, I got an error about being unable to find `cglm.pc`:

```
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/types-struct.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/types.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/util.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/vec2-ext.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/vec2.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/vec3-ext.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/vec3.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/vec4-ext.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/vec4.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/include/cglm/version.h
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/lib/cmake/cglm/cglmConfig.cmake
-- Installing: C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/../install/lib/cmake/cglm/cglmConfig-debug.cmake
CMake Error at libs/cascade/src/libCascade/cglm/cmake_install.cmake:67 (file):
  file INSTALL cannot find
  "C:/MAM/git/csc/concept_editor/build-CascadeEditorConcept1-NO_RTC_Qt_6_4_0_MSVC2022_64bit-Debug/cglm.pc":
  File exists.
Call Stack (most recent call first):
  libs/cascade/src/libCascade/cmake_install.cmake:37 (include)
  libs/cascade/cmake_install.cmake:37 (include)
  cmake_install.cmake:62 (include)
```

`cglm.pc` did not exist at the given path. The project was added as a subdirectory and given a custom build path, where `cglm.pc` actually was. Changing `${CMAKE_BINARY_DIR}` to `${CMAKE_CURRENT_BINARY_DIR}` in CMakeLists.txt fixed the deployment for Qt. 