### PR TITLE
Adding initialization macros for ivec types

### DIFF
--- a/docs/source/ivec2.rst
+++ b/docs/source/ivec2.rst
@@ -8,6 +8,13 @@ Header: cglm/ivec2.h
 Table of contents (click to go):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Macros:
+
+1. GLM_IVEC2_ONE_INIT
+#. GLM_IVEC2_ZERO_INIT
+#. GLM_IVEC2_ONE
+#. GLM_IVEC2_ZERO
+
 Functions:
 
 1. :c:func:`glm_ivec2`

--- a/docs/source/ivec3.rst
+++ b/docs/source/ivec3.rst
@@ -8,6 +8,13 @@ Header: cglm/ivec3.h
 Table of contents (click to go):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Macros:
+
+1. GLM_IVEC3_ONE_INIT
+#. GLM_IVEC3_ZERO_INIT
+#. GLM_IVEC3_ONE
+#. GLM_IVEC3_ZERO
+
 Functions:
 
 1. :c:func:`glm_ivec3`

--- a/docs/source/ivec4.rst
+++ b/docs/source/ivec4.rst
@@ -8,6 +8,13 @@ Header: cglm/ivec4.h
 Table of contents (click to go):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Macros:
+
+1. GLM_IVEC4_ONE_INIT
+#. GLM_IVEC4_ZERO_INIT
+#. GLM_IVEC4_ONE
+#. GLM_IVEC4_ZERO
+
 Functions:
 
 1. :c:func:`glm_ivec4`

--- a/docs/source/vec2.rst
+++ b/docs/source/vec2.rst
@@ -10,10 +10,10 @@ Table of contents (click to go):
 
 Macros:
 
-1. GLM_vec2_ONE_INIT
-#. GLM_vec2_ZERO_INIT
-#. GLM_vec2_ONE
-#. GLM_vec2_ZERO
+1. GLM_VEC2_ONE_INIT
+#. GLM_VEC2_ZERO_INIT
+#. GLM_VEC2_ONE
+#. GLM_VEC2_ZERO
 
 Functions:
 

--- a/include/cglm/ivec2.h
+++ b/include/cglm/ivec2.h
@@ -6,7 +6,13 @@
  */
 
 /*
-FUNCTIONS:
+ Macros:
+   GLM_IVEC2_ONE_INIT
+   GLM_IVEC2_ZERO_INIT
+   GLM_IVEC2_ONE
+   GLM_IVEC2_ZERO
+
+ Functions:
   CGLM_INLINE void glm_ivec2(int * __restrict v, ivec2 dest)
   CGLM_INLINE void glm_ivec2_copy(ivec2 a, ivec2 dest)
   CGLM_INLINE void glm_ivec2_zero(ivec2 v)
@@ -29,6 +35,12 @@ FUNCTIONS:
 #define cglm_ivec2_h
 
 #include "common.h"
+
+#define GLM_IVEC2_ONE_INIT   {1, 1}
+#define GLM_IVEC2_ZERO_INIT  {0, 0}
+
+#define GLM_IVEC2_ONE  ((ivec2)GLM_IVEC2_ONE_INIT)
+#define GLM_IVEC2_ZERO ((ivec2)GLM_IVEC2_ZERO_INIT)
 
 /*!
  * @brief init ivec2 using vec3 or vec4

--- a/include/cglm/ivec3.h
+++ b/include/cglm/ivec3.h
@@ -6,7 +6,13 @@
  */
 
 /*
-FUNCTIONS:
+ Macros:
+   GLM_IVEC3_ONE_INIT
+   GLM_IVEC3_ZERO_INIT
+   GLM_IVEC3_ONE
+   GLM_IVEC3_ZERO
+
+ Functions:
   CGLM_INLINE void glm_ivec3(ivec4 v4, ivec3 dest)
   CGLM_INLINE void glm_ivec3_copy(ivec3 a, ivec3 dest)
   CGLM_INLINE void glm_ivec3_zero(ivec3 v)
@@ -29,6 +35,12 @@ FUNCTIONS:
 #define cglm_ivec3_h
 
 #include "common.h"
+
+#define GLM_IVEC3_ONE_INIT   {1, 1, 1}
+#define GLM_IVEC3_ZERO_INIT  {0, 0, 0}
+
+#define GLM_IVEC3_ONE  ((ivec3)GLM_IVEC3_ONE_INIT)
+#define GLM_IVEC3_ZERO ((ivec3)GLM_IVEC3_ZERO_INIT)
 
 /*!
  * @brief init ivec3 using ivec4

--- a/include/cglm/ivec4.h
+++ b/include/cglm/ivec4.h
@@ -6,7 +6,13 @@
  */
 
 /*
-FUNCTIONS:
+ Macros:
+   GLM_IVEC4_ONE_INIT
+   GLM_IVEC4_ZERO_INIT
+   GLM_IVEC4_ONE
+   GLM_IVEC4_ZERO
+
+ Functions:
   CGLM_INLINE void glm_ivec4(ivec3 v3, int last, ivec4 dest)
   CGLM_INLINE void glm_ivec4_copy(ivec4 a, ivec4 dest)
   CGLM_INLINE void glm_ivec4_zero(ivec4 v)
@@ -29,6 +35,12 @@ FUNCTIONS:
 #define cglm_ivec4_h
 
 #include "common.h"
+
+#define GLM_IVEC4_ONE_INIT   {1, 1, 1, 1}
+#define GLM_IVEC4_ZERO_INIT  {0, 0, 0, 0}
+
+#define GLM_IVEC4_ONE  ((ivec4)GLM_IVEC4_ONE_INIT)
+#define GLM_IVEC4_ZERO ((ivec4)GLM_IVEC4_ZERO_INIT)
 
 /*!
  * @brief init ivec4 using ivec3


### PR DESCRIPTION
added the `GLM_*_ZERO`/`GLM_*_ONE`  macros to ivec2, ivec3 and ivec4. Also fixed a wrong macro from the vec2 docs. 