### PR TITLE
cmake: prevent overriding CMAKE_BUILD_TYPE if it is subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,9 @@ else()
   add_compile_options(-Wall -Werror -O3)
 endif()
 
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+get_directory_property(hasParent PARENT_DIRECTORY)
+
+if(NOT hasParent AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
   set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
We have this configuration:

```CMake
set(DEFAULT_BUILD_TYPE "Release")

...

if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
  message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
  # Set the possible values of build type for cmake-gui
  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
endif()
```
this overrides parent project if parent project don't set BUILD_TYPE e.g Debug. The PR adds additional checks before set build type:

```CMake
get_directory_property(hasParent PARENT_DIRECTORY)

if(NOT hasParent AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
...
```
 
fixes https://github.com/recp/cglm/issues/275

---

references: 
- https://stackoverflow.com/questions/25199677/how-to-detect-if-current-scope-has-a-parent-in-cmake