### PR TITLE
Check for builtin before using it

### DIFF
--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -32,9 +32,13 @@
 #  define CGLM_ALIGN_MAT CGLM_ALIGN(16)
 #endif
 
-#ifdef __GNUC__
-#  define CGLM_ASSUME_ALIGNED(expr, alignment) \
-  __builtin_assume_aligned((expr), (alignment))
+#if defined(__has_builtin)
+#  if __has_builtin(__builtin_assume_aligned)
+#    define CGLM_ASSUME_ALIGNED(expr, alignment) \
+    __builtin_assume_aligned((expr), (alignment))
+#  else
+#    define CGLM_ASSUME_ALIGNED(expr, alignment) (expr)
+#  endif
 #else
 #  define CGLM_ASSUME_ALIGNED(expr, alignment) (expr)
 #endif


### PR DESCRIPTION
This fixes building cglm with compilers that define __GNUC__ and don't implement __builtin_assume_aligned.

Note that the check for __has_builtin being defined and using the __has_builtin() macro need to be on different lines, as when __has_builtin is not defined, using the __has_builtin() macro is an invalid preprocessor directive.