### PR TITLE
struct: provide option to omit struct api namespace e.g. `glms_` and …

### DIFF
--- a/include/cglm/common.h
+++ b/include/cglm/common.h
@@ -82,4 +82,34 @@
 #  endif
 #endif
 
+/* struct API configurator */
+/* TODO: move struct/common.h? */
+/* WARN: dont use concant helpers outside cglm headers, because they may be changed */
+
+#define CGLM_MACRO_CONCAT_HELPER(A, B, C, D, E, ...) A ## B ## C ## D ## E ## __VA_ARGS__
+#define CGLM_MACRO_CONCAT(A, B, C, D, E, ...) CGLM_MACRO_CONCAT_HELPER(A, B, C, D, E,__VA_ARGS__)
+
+#ifndef CGLM_OMIT_NS_FROM_STRUCT_API
+#  ifndef CGLM_STRUCT_API_NS
+#    define CGLM_STRUCT_API_NS glms
+#  endif
+#  ifndef CGLM_STRUCT_API_NS_SEPERATOR
+#    define CGLM_STRUCT_API_NS_SEPERATOR _
+#  endif
+#else
+#  define CGLM_STRUCT_API_NS
+#  define CGLM_STRUCT_API_NS_SEPERATOR
+#endif
+
+#ifndef CGLM_STRUCT_API_NAME_SUFFIX
+#  define CGLM_STRUCT_API_NAME_SUFFIX
+#endif
+
+#define CGLM_STRUCTAPI(A, ...) CGLM_MACRO_CONCAT(CGLM_STRUCT_API_NS,             \
+                                                 CGLM_STRUCT_API_NS_SEPERATOR,   \
+                                                 A,                              \
+                                                 CGLM_STRUCT_API_NAME_SUFFIX,    \
+                                                 _,                              \
+                                                 __VA_ARGS__)
+
 #endif /* cglm_common_h */

--- a/include/cglm/struct/box.h
+++ b/include/cglm/struct/box.h
@@ -15,6 +15,9 @@
 #include "vec4.h"
 #include "mat4.h"
 
+/* api definition */
+#define glms_aabb_(NAME) CGLM_STRUCTAPI(aabb, NAME)
+
 /*!
  * @brief apply transform to Axis-Aligned Bounding Box
  *
@@ -24,7 +27,7 @@
  */
 CGLM_INLINE
 void
-glms_aabb_transform(vec3s box[2], mat4s m, vec3s dest[2]) {
+glms_aabb_(transform)(vec3s box[2], mat4s m, vec3s dest[2]) {
   vec3 rawBox[2];
   vec3 rawDest[2];
 
@@ -45,7 +48,7 @@ glms_aabb_transform(vec3s box[2], mat4s m, vec3s dest[2]) {
  */
 CGLM_INLINE
 void
-glms_aabb_merge(vec3s box1[2], vec3s box2[2], vec3s dest[2]) {
+glms_aabb_(merge)(vec3s box1[2], vec3s box2[2], vec3s dest[2]) {
   vec3 rawBox1[2];
   vec3 rawBox2[2];
   vec3 rawDest[2];
@@ -69,7 +72,7 @@ glms_aabb_merge(vec3s box1[2], vec3s box2[2], vec3s dest[2]) {
  */
 CGLM_INLINE
 void
-glms_aabb_crop(vec3s box[2], vec3s cropBox[2], vec3s dest[2]) {
+glms_aabb_(crop)(vec3s box[2], vec3s cropBox[2], vec3s dest[2]) {
   vec3 rawBox[2];
   vec3 rawCropBox[2];
   vec3 rawDest[2];
@@ -94,10 +97,10 @@ glms_aabb_crop(vec3s box[2], vec3s cropBox[2], vec3s dest[2]) {
  */
 CGLM_INLINE
 void
-glms_aabb_crop_until(vec3s box[2],
-                     vec3s cropBox[2],
-                     vec3s clampBox[2],
-                     vec3s dest[2]) {
+glms_aabb_(crop_until)(vec3s box[2],
+                       vec3s cropBox[2],
+                       vec3s clampBox[2],
+                       vec3s dest[2]) {
   glms_aabb_crop(box, cropBox, dest);
   glms_aabb_merge(clampBox, dest, dest);
 }
@@ -118,7 +121,7 @@ glms_aabb_crop_until(vec3s box[2],
  */
 CGLM_INLINE
 bool
-glms_aabb_frustum(vec3s box[2], vec4s planes[6]) {
+glms_aabb_(frustum)(vec3s box[2], vec4s planes[6]) {
   vec3 rawBox[2];
   vec4 rawPlanes[6];
 
@@ -134,7 +137,7 @@ glms_aabb_frustum(vec3s box[2], vec4s planes[6]) {
  */
 CGLM_INLINE
 void
-glms_aabb_invalidate(vec3s box[2]) {
+glms_aabb_(invalidate)(vec3s box[2]) {
   box[0] = glms_vec3_broadcast(FLT_MAX);
   box[1] = glms_vec3_broadcast(-FLT_MAX);
 }
@@ -146,7 +149,7 @@ glms_aabb_invalidate(vec3s box[2]) {
  */
 CGLM_INLINE
 bool
-glms_aabb_isvalid(vec3s box[2]) {
+glms_aabb_(isvalid)(vec3s box[2]) {
   vec3 rawBox[2];
   glms_vec3_unpack(rawBox, box, 2);
   return glm_aabb_isvalid(rawBox);
@@ -159,7 +162,7 @@ glms_aabb_isvalid(vec3s box[2]) {
  */
 CGLM_INLINE
 float
-glms_aabb_size(vec3s box[2]) {
+glms_aabb_(size)(vec3s box[2]) {
   return glm_vec3_distance(box[0].raw, box[1].raw);
 }
 
@@ -170,7 +173,7 @@ glms_aabb_size(vec3s box[2]) {
  */
 CGLM_INLINE
 float
-glms_aabb_radius(vec3s box[2]) {
+glms_aabb_(radius)(vec3s box[2]) {
   return glms_aabb_size(box) * 0.5f;
 }
 
@@ -182,7 +185,7 @@ glms_aabb_radius(vec3s box[2]) {
  */
 CGLM_INLINE
 vec3s
-glms_aabb_center(vec3s box[2]) {
+glms_aabb_(center)(vec3s box[2]) {
   return glms_vec3_center(box[0], box[1]);
 }
 
@@ -194,7 +197,7 @@ glms_aabb_center(vec3s box[2]) {
  */
 CGLM_INLINE
 bool
-glms_aabb_aabb(vec3s box[2], vec3s other[2]) {
+glms_aabb_(aabb)(vec3s box[2], vec3s other[2]) {
   vec3 rawBox[2];
   vec3 rawOther[2];
 
@@ -214,7 +217,7 @@ glms_aabb_aabb(vec3s box[2], vec3s other[2]) {
  */
 CGLM_INLINE
 bool
-glms_aabb_sphere(vec3s box[2], vec4s s) {
+glms_aabb_(sphere)(vec3s box[2], vec4s s) {
   vec3 rawBox[2];
 
   glms_vec3_unpack(rawBox, box, 2);
@@ -229,7 +232,7 @@ glms_aabb_sphere(vec3s box[2], vec4s s) {
  */
 CGLM_INLINE
 bool
-glms_aabb_point(vec3s box[2], vec3s point) {
+glms_aabb_(point)(vec3s box[2], vec3s point) {
   vec3 rawBox[2];
 
   glms_vec3_unpack(rawBox, box, 2);
@@ -244,7 +247,7 @@ glms_aabb_point(vec3s box[2], vec3s point) {
  */
 CGLM_INLINE
 bool
-glms_aabb_contains(vec3s box[2], vec3s other[2]) {
+glms_aabb_(contains)(vec3s box[2], vec3s other[2]) {
   vec3 rawBox[2];
   vec3 rawOther[2];
 

--- a/include/cglm/struct/mat2.h
+++ b/include/cglm/struct/mat2.h
@@ -36,6 +36,9 @@
 #include "../types-struct.h"
 #include "../mat2.h"
 
+/* api definition */
+#define glms_mat2_(NAME) CGLM_STRUCTAPI(mat2, NAME)
+
 #define GLMS_MAT2_IDENTITY_INIT {GLM_MAT2_IDENTITY_INIT}
 #define GLMS_MAT2_ZERO_INIT     {GLM_MAT2_ZERO_INIT}
 
@@ -59,7 +62,7 @@
  */
 CGLM_INLINE
 mat2s
-glms_mat2_identity(void) {
+glms_mat2_(identity)(void) {
   mat2s r;
   glm_mat2_identity(r.raw);
   return r;
@@ -75,7 +78,7 @@ glms_mat2_identity(void) {
  */
 CGLM_INLINE
 void
-glms_mat2_identity_array(mat2s * __restrict mat, size_t count) {
+glms_mat2_(identity_array)(mat2s * __restrict mat, size_t count) {
   CGLM_ALIGN_MAT mat2s t = GLMS_MAT2_IDENTITY_INIT;
   size_t i;
 
@@ -91,7 +94,7 @@ glms_mat2_identity_array(mat2s * __restrict mat, size_t count) {
  */
 CGLM_INLINE
 mat2s
-glms_mat2_zero(void) {
+glms_mat2_(zero)(void) {
   mat2s r;
   glm_mat2_zero(r.raw);
   return r;
@@ -114,7 +117,7 @@ glms_mat2_zero(void) {
  */
 CGLM_INLINE
 mat2s
-glms_mat2_mul(mat2s m1, mat2s m2) {
+glms_mat2_(mul)(mat2s m1, mat2s m2) {
   mat2s r;
   glm_mat2_mul(m1.raw, m2.raw, r.raw);
   return r;
@@ -129,7 +132,7 @@ glms_mat2_mul(mat2s m1, mat2s m2) {
  */
 CGLM_INLINE
 mat2s
-glms_mat2_transpose(mat2s m) {
+glms_mat2_(transpose)(mat2s m) {
   glm_mat2_transpose(m.raw);
   return m;
 }
@@ -143,7 +146,7 @@ glms_mat2_transpose(mat2s m) {
  */
 CGLM_INLINE
 vec2s
-glms_mat2_mulv(mat2s m, vec2s v) {
+glms_mat2_(mulv)(mat2s m, vec2s v) {
   vec2s r;
   glm_mat2_mulv(m.raw, v.raw, r.raw);
   return r;
@@ -158,7 +161,7 @@ glms_mat2_mulv(mat2s m, vec2s v) {
  */
 CGLM_INLINE
 float
-glms_mat2_trace(mat2s m) {
+glms_mat2_(trace)(mat2s m) {
   return glm_mat2_trace(m.raw);
 }
 
@@ -173,7 +176,7 @@ glms_mat2_trace(mat2s m) {
  */
 CGLM_INLINE
 mat2s
-glms_mat2_scale(mat2s m, float s) {
+glms_mat2_(scale)(mat2s m, float s) {
   glm_mat2_scale(m.raw, s);
   return m;
 }
@@ -187,7 +190,7 @@ glms_mat2_scale(mat2s m, float s) {
  */
 CGLM_INLINE
 float
-glms_mat2_det(mat2s mat) {
+glms_mat2_(det)(mat2s mat) {
   return glm_mat2_det(mat.raw);
 }
 
@@ -199,7 +202,7 @@ glms_mat2_det(mat2s mat) {
  */
 CGLM_INLINE
 mat2s
-glms_mat2_inv(mat2s mat) {
+glms_mat2_(inv)(mat2s mat) {
   mat2s r;
   glm_mat2_inv(mat.raw, r.raw);
   return r;
@@ -215,7 +218,7 @@ glms_mat2_inv(mat2s mat) {
  */
 CGLM_INLINE
 mat2s
-glms_mat2_swap_col(mat2s mat, int col1, int col2) {
+glms_mat2_(swap_col)(mat2s mat, int col1, int col2) {
   glm_mat2_swap_col(mat.raw, col1, col2);
   return mat;
 }
@@ -230,7 +233,7 @@ glms_mat2_swap_col(mat2s mat, int col1, int col2) {
  */
 CGLM_INLINE
 mat2s
-glms_mat2_swap_row(mat2s mat, int row1, int row2) {
+glms_mat2_(swap_row)(mat2s mat, int row1, int row2) {
   glm_mat2_swap_row(mat.raw, row1, row2);
   return mat;
 }
@@ -251,7 +254,7 @@ glms_mat2_swap_row(mat2s mat, int row1, int row2) {
  */
 CGLM_INLINE
 float
-glms_mat2_rmc(vec2s r, mat2s m, vec2s c) {
+glms_mat2_(rmc)(vec2s r, mat2s m, vec2s c) {
   return glm_mat2_rmc(r.raw, m.raw, c.raw);
 }
 

--- a/include/cglm/struct/mat3.h
+++ b/include/cglm/struct/mat3.h
@@ -38,6 +38,9 @@
 #include "../mat3.h"
 #include "vec3.h"
 
+/* api definition */
+#define glms_mat3_(NAME) CGLM_STRUCTAPI(mat3, NAME)
+
 #define GLMS_MAT3_IDENTITY_INIT  {GLM_MAT3_IDENTITY_INIT}
 #define GLMS_MAT3_ZERO_INIT      {GLM_MAT3_ZERO_INIT}
 
@@ -53,7 +56,7 @@
  */
 CGLM_INLINE
 mat3s
-glms_mat3_copy(mat3s mat) {
+glms_mat3_(copy)(mat3s mat) {
   mat3s r;
   glm_mat3_copy(mat.raw, r.raw);
   return r;
@@ -75,7 +78,7 @@ glms_mat3_copy(mat3s mat) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_identity(void) {
+glms_mat3_(identity)(void) {
   mat3s r;
   glm_mat3_identity(r.raw);
   return r;
@@ -91,7 +94,7 @@ glms_mat3_identity(void) {
  */
 CGLM_INLINE
 void
-glms_mat3_identity_array(mat3s * __restrict mat, size_t count) {
+glms_mat3_(identity_array)(mat3s * __restrict mat, size_t count) {
   CGLM_ALIGN_MAT mat3s t = GLMS_MAT3_IDENTITY_INIT;
   size_t i;
 
@@ -107,7 +110,7 @@ glms_mat3_identity_array(mat3s * __restrict mat, size_t count) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_zero(void) {
+glms_mat3_(zero)(void) {
   mat3s r;
   glm_mat3_zero(r.raw);
   return r;
@@ -129,7 +132,7 @@ glms_mat3_zero(void) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_mul(mat3s m1, mat3s m2) {
+glms_mat3_(mul)(mat3s m1, mat3s m2) {
   mat3s r;
   glm_mat3_mul(m1.raw, m2.raw, r.raw);
   return r;
@@ -142,7 +145,7 @@ glms_mat3_mul(mat3s m1, mat3s m2) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_transpose(mat3s m) {
+glms_mat3_(transpose)(mat3s m) {
   glm_mat3_transpose(m.raw);
   return m;
 }
@@ -156,7 +159,7 @@ glms_mat3_transpose(mat3s m) {
  */
 CGLM_INLINE
 vec3s
-glms_mat3_mulv(mat3s m, vec3s v) {
+glms_mat3_(mulv)(mat3s m, vec3s v) {
   vec3s r;
   glm_mat3_mulv(m.raw, v.raw, r.raw);
   return r;
@@ -171,7 +174,7 @@ glms_mat3_mulv(mat3s m, vec3s v) {
  */
 CGLM_INLINE
 float
-glms_mat3_trace(mat3s m) {
+glms_mat3_(trace)(mat3s m) {
   return glm_mat3_trace(m.raw);
 }
 
@@ -183,7 +186,7 @@ glms_mat3_trace(mat3s m) {
  */
 CGLM_INLINE
 versors
-glms_mat3_quat(mat3s m) {
+glms_mat3_(quat)(mat3s m) {
   versors r;
   glm_mat3_quat(m.raw, r.raw);
   return r;
@@ -200,7 +203,7 @@ glms_mat3_quat(mat3s m) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_scale(mat3s m, float s) {
+glms_mat3_(scale)(mat3s m, float s) {
   glm_mat3_scale(m.raw, s);
   return m;
 }
@@ -214,7 +217,7 @@ glms_mat3_scale(mat3s m, float s) {
  */
 CGLM_INLINE
 float
-glms_mat3_det(mat3s mat) {
+glms_mat3_(det)(mat3s mat) {
   return glm_mat3_det(mat.raw);
 }
 
@@ -226,7 +229,7 @@ glms_mat3_det(mat3s mat) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_inv(mat3s mat) {
+glms_mat3_(inv)(mat3s mat) {
   mat3s r;
   glm_mat3_inv(mat.raw, r.raw);
   return r;
@@ -242,7 +245,7 @@ glms_mat3_inv(mat3s mat) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_swap_col(mat3s mat, int col1, int col2) {
+glms_mat3_(swap_col)(mat3s mat, int col1, int col2) {
   glm_mat3_swap_col(mat.raw, col1, col2);
   return mat;
 }
@@ -257,7 +260,7 @@ glms_mat3_swap_col(mat3s mat, int col1, int col2) {
  */
 CGLM_INLINE
 mat3s
-glms_mat3_swap_row(mat3s mat, int row1, int row2) {
+glms_mat3_(swap_row)(mat3s mat, int row1, int row2) {
   glm_mat3_swap_row(mat.raw, row1, row2);
   return mat;
 }
@@ -278,7 +281,7 @@ glms_mat3_swap_row(mat3s mat, int row1, int row2) {
  */
 CGLM_INLINE
 float
-glms_mat3_rmc(vec3s r, mat3s m, vec3s c) {
+glms_mat3_(rmc)(vec3s r, mat3s m, vec3s c) {
   return glm_mat3_rmc(r.raw, m.raw, c.raw);
 }
 

--- a/include/cglm/struct/mat4.h
+++ b/include/cglm/struct/mat4.h
@@ -53,6 +53,9 @@
 #include "vec4.h"
 #include "vec3.h"
 
+/* api definition */ 
+#define glms_mat4_(NAME) CGLM_STRUCTAPI(mat4, NAME)
+
 #define GLMS_MAT4_IDENTITY_INIT  {GLM_MAT4_IDENTITY_INIT}
 #define GLMS_MAT4_ZERO_INIT      {GLM_MAT4_ZERO_INIT}
 
@@ -71,7 +74,7 @@
  */
 CGLM_INLINE
 mat4s
-glms_mat4_ucopy(mat4s mat) {
+glms_mat4_(ucopy)(mat4s mat) {
   mat4s r;
   glm_mat4_ucopy(mat.raw, r.raw);
   return r;
@@ -85,7 +88,7 @@ glms_mat4_ucopy(mat4s mat) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_copy(mat4s mat) {
+glms_mat4_(copy)(mat4s mat) {
   mat4s r;
   glm_mat4_copy(mat.raw, r.raw);
   return r;
@@ -107,7 +110,7 @@ glms_mat4_copy(mat4s mat) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_identity(void) {
+glms_mat4_(identity)(void) {
   mat4s r;
   glm_mat4_identity(r.raw);
   return r;
@@ -123,7 +126,7 @@ glms_mat4_identity(void) {
  */
 CGLM_INLINE
 void
-glms_mat4_identity_array(mat4s * __restrict mat, size_t count) {
+glms_mat4_(identity_array)(mat4s * __restrict mat, size_t count) {
   CGLM_ALIGN_MAT mat4s t = GLMS_MAT4_IDENTITY_INIT;
   size_t i;
 
@@ -139,7 +142,7 @@ glms_mat4_identity_array(mat4s * __restrict mat, size_t count) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_zero(void) {
+glms_mat4_(zero)(void) {
   mat4s r;
   glm_mat4_zero(r.raw);
   return r;
@@ -153,7 +156,7 @@ glms_mat4_zero(void) {
  */
 CGLM_INLINE
 mat3s
-glms_mat4_pick3(mat4s mat) {
+glms_mat4_(pick3)(mat4s mat) {
   mat3s r;
   glm_mat4_pick3(mat.raw, r.raw);
   return r;
@@ -169,7 +172,7 @@ glms_mat4_pick3(mat4s mat) {
  */
 CGLM_INLINE
 mat3s
-glms_mat4_pick3t(mat4s mat) {
+glms_mat4_(pick3t)(mat4s mat) {
   mat3s r;
   glm_mat4_pick3t(mat.raw, r.raw);
   return r;
@@ -183,7 +186,7 @@ glms_mat4_pick3t(mat4s mat) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_ins3(mat3s mat) {
+glms_mat4_(ins3)(mat3s mat) {
   mat4s r;
   glm_mat4_ins3(mat.raw, r.raw);
   return r;
@@ -205,7 +208,7 @@ glms_mat4_ins3(mat3s mat) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_mul(mat4s m1, mat4s m2) {
+glms_mat4_(mul)(mat4s m1, mat4s m2) {
   mat4s r;
   glm_mat4_mul(m1.raw, m2.raw, r.raw);
   return r;
@@ -232,7 +235,7 @@ glms_mat4_mul(mat4s m1, mat4s m2) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_mulN(mat4s * __restrict matrices[], uint32_t len) {
+glms_mat4_(mulN)(mat4s * __restrict matrices[], uint32_t len) {
   CGLM_ALIGN_MAT mat4s r = GLMS_MAT4_IDENTITY_INIT;
   size_t i;
 
@@ -252,7 +255,7 @@ glms_mat4_mulN(mat4s * __restrict matrices[], uint32_t len) {
  */
 CGLM_INLINE
 vec4s
-glms_mat4_mulv(mat4s m, vec4s v) {
+glms_mat4_(mulv)(mat4s m, vec4s v) {
   vec4s r;
   glm_mat4_mulv(m.raw, v.raw, r.raw);
   return r;
@@ -267,7 +270,7 @@ glms_mat4_mulv(mat4s m, vec4s v) {
  */
 CGLM_INLINE
 float
-glms_mat4_trace(mat4s m) {
+glms_mat4_(trace)(mat4s m) {
   return glm_mat4_trace(m.raw);
 }
 
@@ -280,7 +283,7 @@ glms_mat4_trace(mat4s m) {
  */
 CGLM_INLINE
 float
-glms_mat4_trace3(mat4s m) {
+glms_mat4_(trace3)(mat4s m) {
   return glm_mat4_trace3(m.raw);
 }
 
@@ -292,7 +295,7 @@ glms_mat4_trace3(mat4s m) {
  */
 CGLM_INLINE
 versors
-glms_mat4_quat(mat4s m) {
+glms_mat4_(quat)(mat4s m) {
   versors r;
   glm_mat4_quat(m.raw, r.raw);
   return r;
@@ -308,7 +311,7 @@ glms_mat4_quat(mat4s m) {
  */
 CGLM_INLINE
 vec3s
-glms_mat4_mulv3(mat4s m, vec3s v, float last) {
+glms_mat4_(mulv3)(mat4s m, vec3s v, float last) {
   vec3s r;
   glm_mat4_mulv3(m.raw, v.raw, last, r.raw);
   return r;
@@ -322,7 +325,7 @@ glms_mat4_mulv3(mat4s m, vec3s v, float last) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_transpose(mat4s m) {
+glms_mat4_(transpose)(mat4s m) {
   glm_mat4_transpose(m.raw);
   return m;
 }
@@ -338,7 +341,7 @@ glms_mat4_transpose(mat4s m) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_scale_p(mat4s m, float s) {
+glms_mat4_(scale_p)(mat4s m, float s) {
   glm_mat4_scale_p(m.raw, s);
   return m;
 }
@@ -354,7 +357,7 @@ glms_mat4_scale_p(mat4s m, float s) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_scale(mat4s m, float s) {
+glms_mat4_(scale)(mat4s m, float s) {
   glm_mat4_scale(m.raw, s);
   return m;
 }
@@ -368,7 +371,7 @@ glms_mat4_scale(mat4s m, float s) {
  */
 CGLM_INLINE
 float
-glms_mat4_det(mat4s mat) {
+glms_mat4_(det)(mat4s mat) {
   return glm_mat4_det(mat.raw);
 }
 
@@ -380,7 +383,7 @@ glms_mat4_det(mat4s mat) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_inv(mat4s mat) {
+glms_mat4_(inv)(mat4s mat) {
   mat4s r;
   glm_mat4_inv(mat.raw, r.raw);
   return r;
@@ -400,7 +403,7 @@ glms_mat4_inv(mat4s mat) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_inv_fast(mat4s mat) {
+glms_mat4_(inv_fast)(mat4s mat) {
   mat4s r;
   glm_mat4_inv_fast(mat.raw, r.raw);
   return r;
@@ -416,7 +419,7 @@ glms_mat4_inv_fast(mat4s mat) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_swap_col(mat4s mat, int col1, int col2) {
+glms_mat4_(swap_col)(mat4s mat, int col1, int col2) {
   glm_mat4_swap_col(mat.raw, col1, col2);
   return mat;
 }
@@ -431,7 +434,7 @@ glms_mat4_swap_col(mat4s mat, int col1, int col2) {
  */
 CGLM_INLINE
 mat4s
-glms_mat4_swap_row(mat4s mat, int row1, int row2) {
+glms_mat4_(swap_row)(mat4s mat, int row1, int row2) {
   glm_mat4_swap_row(mat.raw, row1, row2);
   return mat;
 }
@@ -452,7 +455,7 @@ glms_mat4_swap_row(mat4s mat, int row1, int row2) {
  */
 CGLM_INLINE
 float
-glms_mat4_rmc(vec4s r, mat4s m, vec4s c) {
+glms_mat4_(rmc)(vec4s r, mat4s m, vec4s c) {
   return glm_mat4_rmc(r.raw, m.raw, c.raw);
 }
 

--- a/include/cglm/struct/quat.h
+++ b/include/cglm/struct/quat.h
@@ -54,6 +54,9 @@
 #include "../plane.h"
 #include "../quat.h"
 
+/* api definition */
+#define glms_quat_(NAME) CGLM_STRUCTAPI(quat, NAME)
+
 /*
  * IMPORTANT:
  * ----------------------------------------------------------------------------
@@ -74,7 +77,7 @@
  */
 CGLM_INLINE
 versors
-glms_quat_identity(void) {
+glms_quat_(identity)(void) {
   versors dest;
   glm_quat_identity(dest.raw);
   return dest;
@@ -90,7 +93,7 @@ glms_quat_identity(void) {
  */
 CGLM_INLINE
 void
-glms_quat_identity_array(versors * __restrict q, size_t count) {
+glms_quat_(identity_array)(versors * __restrict q, size_t count) {
   CGLM_ALIGN(16) versor v = GLM_QUAT_IDENTITY_INIT;
   size_t i;
 
@@ -110,7 +113,7 @@ glms_quat_identity_array(versors * __restrict q, size_t count) {
  */
 CGLM_INLINE
 versors
-glms_quat_init(float x, float y, float z, float w) {
+glms_quat_(init)(float x, float y, float z, float w) {
   versors dest;
   glm_quat_init(dest.raw, x, y, z, w);
   return dest;
@@ -157,7 +160,7 @@ glms_quat(float angle, float x, float y, float z) {
  */
 CGLM_INLINE
 versors
-glms_quat_from_vecs(vec3s a, vec3s b) {
+glms_quat_(from_vecs)(vec3s a, vec3s b) {
   versors dest;
   glm_quat_from_vecs(a.raw, b.raw, dest.raw);
   return dest;
@@ -170,7 +173,7 @@ glms_quat_from_vecs(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 float
-glms_quat_norm(versors q) {
+glms_quat_(norm)(versors q) {
   return glm_quat_norm(q.raw);
 }
 
@@ -182,7 +185,7 @@ glms_quat_norm(versors q) {
  */
 CGLM_INLINE
 versors
-glms_quat_normalize(versors q) {
+glms_quat_(normalize)(versors q) {
   versors dest;
   glm_quat_normalize_to(q.raw, dest.raw);
   return dest;
@@ -197,7 +200,7 @@ glms_quat_normalize(versors q) {
  */
 CGLM_INLINE
 float
-glms_quat_dot(versors p, versors q) {
+glms_quat_(dot)(versors p, versors q) {
   return glm_quat_dot(p.raw, q.raw);
 }
 
@@ -209,7 +212,7 @@ glms_quat_dot(versors p, versors q) {
  */
 CGLM_INLINE
 versors
-glms_quat_conjugate(versors q) {
+glms_quat_(conjugate)(versors q) {
   versors dest;
   glm_quat_conjugate(q.raw, dest.raw);
   return dest;
@@ -223,7 +226,7 @@ glms_quat_conjugate(versors q) {
  */
 CGLM_INLINE
 versors
-glms_quat_inv(versors q) {
+glms_quat_(inv)(versors q) {
   versors dest;
   glm_quat_inv(q.raw, dest.raw);
   return dest;
@@ -238,7 +241,7 @@ glms_quat_inv(versors q) {
  */
 CGLM_INLINE
 versors
-glms_quat_add(versors p, versors q) {
+glms_quat_(add)(versors p, versors q) {
   versors dest;
   glm_quat_add(p.raw, q.raw, dest.raw);
   return dest;
@@ -253,7 +256,7 @@ glms_quat_add(versors p, versors q) {
  */
 CGLM_INLINE
 versors
-glms_quat_sub(versors p, versors q) {
+glms_quat_(sub)(versors p, versors q) {
   versors dest;
   glm_quat_sub(p.raw, q.raw, dest.raw);
   return dest;
@@ -266,7 +269,7 @@ glms_quat_sub(versors p, versors q) {
  */
 CGLM_INLINE
 vec3s
-glms_quat_imagn(versors q) {
+glms_quat_(imagn)(versors q) {
   vec3s dest;
   glm_normalize_to(q.raw, dest.raw);
   return dest;
@@ -279,7 +282,7 @@ glms_quat_imagn(versors q) {
  */
 CGLM_INLINE
 float
-glms_quat_imaglen(versors q) {
+glms_quat_(imaglen)(versors q) {
   return glm_quat_imaglen(q.raw);
 }
 
@@ -290,7 +293,7 @@ glms_quat_imaglen(versors q) {
  */
 CGLM_INLINE
 float
-glms_quat_angle(versors q) {
+glms_quat_(angle)(versors q) {
   return glm_quat_angle(q.raw);
 }
 
@@ -302,7 +305,7 @@ glms_quat_angle(versors q) {
  */
 CGLM_INLINE
 vec3s
-glms_quat_axis(versors q) {
+glms_quat_(axis)(versors q) {
   vec3s dest;
   glm_quat_axis(q.raw, dest.raw);
   return dest;
@@ -322,7 +325,7 @@ glms_quat_axis(versors q) {
  */
 CGLM_INLINE
 versors
-glms_quat_mul(versors p, versors q) {
+glms_quat_(mul)(versors p, versors q) {
   versors dest;
   glm_quat_mul(p.raw, q.raw, dest.raw);
   return dest;
@@ -336,7 +339,7 @@ glms_quat_mul(versors p, versors q) {
  */
 CGLM_INLINE
 mat4s
-glms_quat_mat4(versors q) {
+glms_quat_(mat4)(versors q) {
   mat4s dest;
   glm_quat_mat4(q.raw, dest.raw);
   return dest;
@@ -350,7 +353,7 @@ glms_quat_mat4(versors q) {
  */
 CGLM_INLINE
 mat4s
-glms_quat_mat4t(versors q) {
+glms_quat_(mat4t)(versors q) {
   mat4s dest;
   glm_quat_mat4t(q.raw, dest.raw);
   return dest;
@@ -364,7 +367,7 @@ glms_quat_mat4t(versors q) {
  */
 CGLM_INLINE
 mat3s
-glms_quat_mat3(versors q) {
+glms_quat_(mat3)(versors q) {
   mat3s dest;
   glm_quat_mat3(q.raw, dest.raw);
   return dest;
@@ -378,7 +381,7 @@ glms_quat_mat3(versors q) {
  */
 CGLM_INLINE
 mat3s
-glms_quat_mat3t(versors q) {
+glms_quat_(mat3t)(versors q) {
   mat3s dest;
   glm_quat_mat3t(q.raw, dest.raw);
   return dest;
@@ -395,7 +398,7 @@ glms_quat_mat3t(versors q) {
  */
 CGLM_INLINE
 versors
-glms_quat_lerp(versors from, versors to, float t) {
+glms_quat_(lerp)(versors from, versors to, float t) {
   versors dest;
   glm_quat_lerp(from.raw, to.raw, t, dest.raw);
   return dest;
@@ -412,7 +415,7 @@ glms_quat_lerp(versors from, versors to, float t) {
  */
 CGLM_INLINE
 versors
-glms_quat_lerpc(versors from, versors to, float t) {
+glms_quat_(lerpc)(versors from, versors to, float t) {
   versors dest;
   glm_quat_lerpc(from.raw, to.raw, t, dest.raw);
   return dest;
@@ -430,7 +433,7 @@ glms_quat_lerpc(versors from, versors to, float t) {
  */
 CGLM_INLINE
 versors
-glms_quat_nlerp(versors from, versors to, float t) {
+glms_quat_(nlerp)(versors from, versors to, float t) {
   versors dest;
   glm_quat_nlerp(from.raw, to.raw, t, dest.raw);
   return dest;
@@ -447,7 +450,7 @@ glms_quat_nlerp(versors from, versors to, float t) {
  */
 CGLM_INLINE
 versors
-glms_quat_slerp(versors from, versors to, float t) {
+glms_quat_(slerp)(versors from, versors to, float t) {
   versors dest;
   glm_quat_slerp(from.raw, to.raw, t, dest.raw);
   return dest;
@@ -462,7 +465,7 @@ glms_quat_slerp(versors from, versors to, float t) {
  */
 CGLM_INLINE
 mat4s
-glms_quat_look(vec3s eye, versors ori) {
+glms_quat_(look)(vec3s eye, versors ori) {
   mat4s dest;
   glm_quat_look(eye.raw, ori.raw, dest.raw);
   return dest;
@@ -477,7 +480,7 @@ glms_quat_look(vec3s eye, versors ori) {
  */
 CGLM_INLINE
 versors
-glms_quat_for(vec3s dir, vec3s up) {
+glms_quat_(for)(vec3s dir, vec3s up) {
   versors dest;
   glm_quat_for(dir.raw, up.raw, dest.raw);
   return dest;
@@ -494,7 +497,7 @@ glms_quat_for(vec3s dir, vec3s up) {
  */
 CGLM_INLINE
 versors
-glms_quat_forp(vec3s from, vec3s to, vec3s up) {
+glms_quat_(forp)(vec3s from, vec3s to, vec3s up) {
   versors dest;
   glm_quat_forp(from.raw, to.raw, up.raw, dest.raw);
   return dest;
@@ -509,7 +512,7 @@ glms_quat_forp(vec3s from, vec3s to, vec3s up) {
  */
 CGLM_INLINE
 vec3s
-glms_quat_rotatev(versors q, vec3s v) {
+glms_quat_(rotatev)(versors q, vec3s v) {
   vec3s dest;
   glm_quat_rotatev(q.raw, v.raw, dest.raw);
   return dest;
@@ -524,7 +527,7 @@ glms_quat_rotatev(versors q, vec3s v) {
  */
 CGLM_INLINE
 mat4s
-glms_quat_rotate(mat4s m, versors q) {
+glms_quat_(rotate)(mat4s m, versors q) {
   glm_quat_rotate(m.raw, q.raw, m.raw);
   return m;
 }
@@ -538,7 +541,7 @@ glms_quat_rotate(mat4s m, versors q) {
  */
 CGLM_INLINE
 mat4s
-glms_quat_rotate_at(mat4s m, versors q, vec3s pivot) {
+glms_quat_(rotate_at)(mat4s m, versors q, vec3s pivot) {
   glm_quat_rotate_at(m.raw, q.raw, pivot.raw);
   return m;
 }
@@ -556,7 +559,7 @@ glms_quat_rotate_at(mat4s m, versors q, vec3s pivot) {
  */
 CGLM_INLINE
 mat4s
-glms_quat_rotate_atm(versors q, vec3s pivot) {
+glms_quat_(rotate_atm)(versors q, vec3s pivot) {
   mat4s dest;
   glm_quat_rotate_atm(dest.raw, q.raw, pivot.raw);
   return dest;

--- a/include/cglm/struct/vec2-ext.h
+++ b/include/cglm/struct/vec2-ext.h
@@ -34,6 +34,9 @@
 #include "../util.h"
 #include "../vec2-ext.h"
 
+/* api definition */
+#define glms_vec2_(NAME) CGLM_STRUCTAPI(vec2, NAME)
+
 /*!
  * @brief fill a vector with specified value
  *
@@ -42,7 +45,7 @@
  */
 CGLM_INLINE
 vec2s
-glms_vec2_fill(float val) {
+glms_vec2_(fill)(float val) {
   vec2s r;
   glm_vec2_fill(r.raw, val);
   return r;
@@ -56,7 +59,7 @@ glms_vec2_fill(float val) {
  */
 CGLM_INLINE
 bool
-glms_vec2_eq(vec2s v, float val) {
+glms_vec2_(eq)(vec2s v, float val) {
   return glm_vec2_eq(v.raw, val);
 }
 
@@ -68,7 +71,7 @@ glms_vec2_eq(vec2s v, float val) {
  */
 CGLM_INLINE
 bool
-glms_vec2_eq_eps(vec2s v, float val) {
+glms_vec2_(eq_eps)(vec2s v, float val) {
   return glm_vec2_eq_eps(v.raw, val);
 }
 
@@ -79,7 +82,7 @@ glms_vec2_eq_eps(vec2s v, float val) {
  */
 CGLM_INLINE
 bool
-glms_vec2_eq_all(vec2s v) {
+glms_vec2_(eq_all)(vec2s v) {
   return glm_vec2_eq_all(v.raw);
 }
 
@@ -91,7 +94,7 @@ glms_vec2_eq_all(vec2s v) {
  */
 CGLM_INLINE
 bool
-glms_vec2_eqv(vec2s a, vec2s b) {
+glms_vec2_(eqv)(vec2s a, vec2s b) {
   return glm_vec2_eqv(a.raw, b.raw);
 }
 
@@ -103,7 +106,7 @@ glms_vec2_eqv(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 bool
-glms_vec2_eqv_eps(vec2s a, vec2s b) {
+glms_vec2_(eqv_eps)(vec2s a, vec2s b) {
   return glm_vec2_eqv_eps(a.raw, b.raw);
 }
 
@@ -114,7 +117,7 @@ glms_vec2_eqv_eps(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 float
-glms_vec2_max(vec2s v) {
+glms_vec2_(max)(vec2s v) {
   return glm_vec2_max(v.raw);
 }
 
@@ -137,7 +140,7 @@ glms_vec2_min(vec2s v) {
  */
 CGLM_INLINE
 bool
-glms_vec2_isnan(vec2s v) {
+glms_vec2_(isnan)(vec2s v) {
   return glm_vec2_isnan(v.raw);
 }
 
@@ -149,7 +152,7 @@ glms_vec2_isnan(vec2s v) {
  */
 CGLM_INLINE
 bool
-glms_vec2_isinf(vec2s v) {
+glms_vec2_(isinf)(vec2s v) {
   return glm_vec2_isinf(v.raw);
 }
 
@@ -175,7 +178,7 @@ glms_vec2_isvalid(vec2s v) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_sign(vec2s v) {
+glms_vec2_(sign)(vec2s v) {
   vec2s r;
   glm_vec2_sign(v.raw, r.raw);
   return r;
@@ -189,7 +192,7 @@ glms_vec2_sign(vec2s v) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_sqrt(vec2s v) {
+glms_vec2_(sqrt)(vec2s v) {
   vec2s r;
   glm_vec2_sqrt(v.raw, r.raw);
   return r;
@@ -204,7 +207,7 @@ glms_vec2_sqrt(vec2s v) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_complex_mul(vec2s a, vec2s b, vec2s dest) {
+glms_vec2_(complex_mul)(vec2s a, vec2s b, vec2s dest) {
   glm_vec2_complex_mul(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -218,7 +221,7 @@ glms_vec2_complex_mul(vec2s a, vec2s b, vec2s dest) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_complex_div(vec2s a, vec2s b, vec2s dest) {
+glms_vec2_(complex_div)(vec2s a, vec2s b, vec2s dest) {
   glm_vec2_complex_div(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -231,7 +234,7 @@ glms_vec2_complex_div(vec2s a, vec2s b, vec2s dest) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_complex_conjugate(vec2s a, vec2s dest) {
+glms_vec2_(complex_conjugate)(vec2s a, vec2s dest) {
   glm_vec2_complex_conjugate(a.raw, dest.raw);
   return dest;
 }

--- a/include/cglm/struct/vec2.h
+++ b/include/cglm/struct/vec2.h
@@ -86,7 +86,7 @@ glms_vec2(vec3s v3) {
  */
 CGLM_INLINE
 void
-glms_vec2_pack(vec2s dst[], vec2 src[], size_t len) {
+glms_vec2_(pack)(vec2s dst[], vec2 src[], size_t len) {
   size_t i;
 
   for (i = 0; i < len; i++) {
@@ -103,7 +103,7 @@ glms_vec2_pack(vec2s dst[], vec2 src[], size_t len) {
  */
 CGLM_INLINE
 void
-glms_vec2_unpack(vec2 dst[], vec2s src[], size_t len) {
+glms_vec2_(unpack)(vec2 dst[], vec2s src[], size_t len) {
   size_t i;
 
   for (i = 0; i < len; i++) {
@@ -118,7 +118,7 @@ glms_vec2_unpack(vec2 dst[], vec2s src[], size_t len) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_zero(void) {
+glms_vec2_(zero)(void) {
   vec2s r;
   glm_vec2_zero(r.raw);
   return r;
@@ -131,7 +131,7 @@ glms_vec2_zero(void) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_one(void) {
+glms_vec2_(one)(void) {
   vec2s r;
   glm_vec2_one(r.raw);
   return r;
@@ -147,7 +147,7 @@ glms_vec2_one(void) {
  */
 CGLM_INLINE
 float
-glms_vec2_dot(vec2s a, vec2s b) {
+glms_vec2_(dot)(vec2s a, vec2s b) {
   return glm_vec2_dot(a.raw, b.raw);
 }
 
@@ -163,7 +163,7 @@ glms_vec2_dot(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 float
-glms_vec2_cross(vec2s a, vec2s b) {
+glms_vec2_(cross)(vec2s a, vec2s b) {
   return glm_vec2_cross(a.raw, b.raw);
 }
 
@@ -180,7 +180,7 @@ glms_vec2_cross(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 float
-glms_vec2_norm2(vec2s v) {
+glms_vec2_(norm2)(vec2s v) {
   return glm_vec2_norm2(v.raw);
 }
 
@@ -193,7 +193,7 @@ glms_vec2_norm2(vec2s v) {
  */
 CGLM_INLINE
 float
-glms_vec2_norm(vec2s v) {
+glms_vec2_(norm)(vec2s v) {
   return glm_vec2_norm(v.raw);
 }
 
@@ -206,7 +206,7 @@ glms_vec2_norm(vec2s v) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_add(vec2s a, vec2s b) {
+glms_vec2_(add)(vec2s a, vec2s b) {
   vec2s r;
   glm_vec2_add(a.raw, b.raw, r.raw);
   return r;
@@ -221,7 +221,7 @@ glms_vec2_add(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_adds(vec2s a, float s) {
+glms_vec2_(adds)(vec2s a, float s) {
   vec2s r;
   glm_vec2_adds(a.raw, s, r.raw);
   return r;
@@ -236,7 +236,7 @@ glms_vec2_adds(vec2s a, float s) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_sub(vec2s a, vec2s b) {
+glms_vec2_(sub)(vec2s a, vec2s b) {
   vec2s r;
   glm_vec2_sub(a.raw, b.raw, r.raw);
   return r;
@@ -251,7 +251,7 @@ glms_vec2_sub(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_subs(vec2s a, float s) {
+glms_vec2_(subs)(vec2s a, float s) {
   vec2s r;
   glm_vec2_subs(a.raw, s, r.raw);
   return r;
@@ -266,7 +266,7 @@ glms_vec2_subs(vec2s a, float s) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_mul(vec2s a, vec2s b) {
+glms_vec2_(mul)(vec2s a, vec2s b) {
   vec2s r;
   glm_vec2_mul(a.raw, b.raw, r.raw);
   return r;
@@ -281,7 +281,7 @@ glms_vec2_mul(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_scale(vec2s v, float s) {
+glms_vec2_(scale)(vec2s v, float s) {
   vec2s r;
   glm_vec2_scale(v.raw, s, r.raw);
   return r;
@@ -296,7 +296,7 @@ glms_vec2_scale(vec2s v, float s) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_scale_as(vec2s v, float s) {
+glms_vec2_(scale_as)(vec2s v, float s) {
   vec2s r;
   glm_vec2_scale_as(v.raw, s, r.raw);
   return r;
@@ -311,7 +311,7 @@ glms_vec2_scale_as(vec2s v, float s) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_div(vec2s a, vec2s b) {
+glms_vec2_(div)(vec2s a, vec2s b) {
   vec2s r;
   glm_vec2_div(a.raw, b.raw, r.raw);
   return r;
@@ -326,7 +326,7 @@ glms_vec2_div(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_divs(vec2s a, float s) {
+glms_vec2_(divs)(vec2s a, float s) {
   vec2s r;
   glm_vec2_divs(a.raw, s, r.raw);
   return r;
@@ -343,7 +343,7 @@ glms_vec2_divs(vec2s a, float s) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_addadd(vec2s a, vec2s b, vec2s dest) {
+glms_vec2_(addadd)(vec2s a, vec2s b, vec2s dest) {
   glm_vec2_addadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -359,7 +359,7 @@ glms_vec2_addadd(vec2s a, vec2s b, vec2s dest) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_subadd(vec2s a, vec2s b, vec2s dest) {
+glms_vec2_(subadd)(vec2s a, vec2s b, vec2s dest) {
   glm_vec2_subadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -375,7 +375,7 @@ glms_vec2_subadd(vec2s a, vec2s b, vec2s dest) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_muladd(vec2s a, vec2s b, vec2s dest) {
+glms_vec2_(muladd)(vec2s a, vec2s b, vec2s dest) {
   glm_vec2_muladd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -391,7 +391,7 @@ glms_vec2_muladd(vec2s a, vec2s b, vec2s dest) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_muladds(vec2s a, float s, vec2s dest) {
+glms_vec2_(muladds)(vec2s a, float s, vec2s dest) {
   glm_vec2_muladds(a.raw, s, dest.raw);
   return dest;
 }
@@ -407,7 +407,7 @@ glms_vec2_muladds(vec2s a, float s, vec2s dest) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_maxadd(vec2s a, vec2s b, vec2s dest) {
+glms_vec2_(maxadd)(vec2s a, vec2s b, vec2s dest) {
   glm_vec2_maxadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -423,7 +423,7 @@ glms_vec2_maxadd(vec2s a, vec2s b, vec2s dest) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_minadd(vec2s a, vec2s b, vec2s dest) {
+glms_vec2_(minadd)(vec2s a, vec2s b, vec2s dest) {
   glm_vec2_minadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -436,7 +436,7 @@ glms_vec2_minadd(vec2s a, vec2s b, vec2s dest) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_negate(vec2s v) {
+glms_vec2_(negate)(vec2s v) {
   glm_vec2_negate(v.raw);
   return v;
 }
@@ -449,7 +449,7 @@ glms_vec2_negate(vec2s v) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_normalize(vec2s v) {
+glms_vec2_(normalize)(vec2s v) {
   glm_vec2_normalize(v.raw);
   return v;
 }
@@ -463,7 +463,7 @@ glms_vec2_normalize(vec2s v) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_rotate(vec2s v, float angle) {
+glms_vec2_(rotate)(vec2s v, float angle) {
   vec2s r;
   glm_vec2_rotate(v.raw, angle, r.raw);
   return r;
@@ -478,7 +478,7 @@ glms_vec2_rotate(vec2s v, float angle) {
  */
 CGLM_INLINE
 float
-glms_vec2_distance(vec2s a, vec2s b) {
+glms_vec2_(distance)(vec2s a, vec2s b) {
   return glm_vec2_distance(a.raw, b.raw);
 }
 
@@ -491,7 +491,7 @@ glms_vec2_distance(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 float
-glms_vec2_distance2(vec2s a, vec2s b) {
+glms_vec2_(distance2)(vec2s a, vec2s b) {
   return glm_vec2_distance2(a.raw, b.raw);
 }
 
@@ -504,7 +504,7 @@ glms_vec2_distance2(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_maxv(vec2s a, vec2s b) {
+glms_vec2_(maxv)(vec2s a, vec2s b) {
   vec2s r;
   glm_vec2_maxv(a.raw, b.raw, r.raw);
   return r;
@@ -519,7 +519,7 @@ glms_vec2_maxv(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_minv(vec2s a, vec2s b) {
+glms_vec2_(minv)(vec2s a, vec2s b) {
   vec2s r;
   glm_vec2_minv(a.raw, b.raw, r.raw);
   return r;
@@ -535,7 +535,7 @@ glms_vec2_minv(vec2s a, vec2s b) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_clamp(vec2s v, float minVal, float maxVal) {
+glms_vec2_(clamp)(vec2s v, float minVal, float maxVal) {
   glm_vec2_clamp(v.raw, minVal, maxVal);
   return v;
 }
@@ -552,7 +552,7 @@ glms_vec2_clamp(vec2s v, float minVal, float maxVal) {
  */
 CGLM_INLINE
 vec2s
-glms_vec2_lerp(vec2s from, vec2s to, float t) {
+glms_vec2_(lerp)(vec2s from, vec2s to, float t) {
   vec2s r;
   glm_vec2_lerp(from.raw, to.raw, t, r.raw);
   return r;

--- a/include/cglm/struct/vec3-ext.h
+++ b/include/cglm/struct/vec3-ext.h
@@ -38,6 +38,9 @@
 #include "../util.h"
 #include "../vec3-ext.h"
 
+/* api definition */
+#define glms_vec3_(NAME) CGLM_STRUCTAPI(vec3, NAME)
+
 /*!
  * @brief fill a vector with specified value
  *
@@ -46,7 +49,7 @@
  */
 CGLM_INLINE
 vec3s
-glms_vec3_broadcast(float val) {
+glms_vec3_(broadcast)(float val) {
   vec3s r;
   glm_vec3_broadcast(val, r.raw);
   return r;
@@ -60,7 +63,7 @@ glms_vec3_broadcast(float val) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_fill(float val) {
+glms_vec3_(fill)(float val) {
   vec3s r;
   glm_vec3_fill(r.raw, val);
   return r;
@@ -74,7 +77,7 @@ glms_vec3_fill(float val) {
  */
 CGLM_INLINE
 bool
-glms_vec3_eq(vec3s v, float val) {
+glms_vec3_(eq)(vec3s v, float val) {
   return glm_vec3_eq(v.raw, val);
 }
 
@@ -86,7 +89,7 @@ glms_vec3_eq(vec3s v, float val) {
  */
 CGLM_INLINE
 bool
-glms_vec3_eq_eps(vec3s v, float val) {
+glms_vec3_(eq_eps)(vec3s v, float val) {
   return glm_vec3_eq_eps(v.raw, val);
 }
 
@@ -97,7 +100,7 @@ glms_vec3_eq_eps(vec3s v, float val) {
  */
 CGLM_INLINE
 bool
-glms_vec3_eq_all(vec3s v) {
+glms_vec3_(eq_all)(vec3s v) {
   return glm_vec3_eq_all(v.raw);
 }
 
@@ -109,7 +112,7 @@ glms_vec3_eq_all(vec3s v) {
  */
 CGLM_INLINE
 bool
-glms_vec3_eqv(vec3s a, vec3s b) {
+glms_vec3_(eqv)(vec3s a, vec3s b) {
   return glm_vec3_eqv(a.raw, b.raw);
 }
 
@@ -121,7 +124,7 @@ glms_vec3_eqv(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 bool
-glms_vec3_eqv_eps(vec3s a, vec3s b) {
+glms_vec3_(eqv_eps)(vec3s a, vec3s b) {
   return glm_vec3_eqv_eps(a.raw, b.raw);
 }
 
@@ -132,7 +135,7 @@ glms_vec3_eqv_eps(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 float
-glms_vec3_max(vec3s v) {
+glms_vec3_(max)(vec3s v) {
   return glm_vec3_max(v.raw);
 }
 
@@ -143,7 +146,7 @@ glms_vec3_max(vec3s v) {
  */
 CGLM_INLINE
 float
-glms_vec3_min(vec3s v) {
+glms_vec3_(min)(vec3s v) {
   return glm_vec3_min(v.raw);
 }
 
@@ -155,7 +158,7 @@ glms_vec3_min(vec3s v) {
  */
 CGLM_INLINE
 bool
-glms_vec3_isnan(vec3s v) {
+glms_vec3_(isnan)(vec3s v) {
   return glm_vec3_isnan(v.raw);
 }
 
@@ -167,7 +170,7 @@ glms_vec3_isnan(vec3s v) {
  */
 CGLM_INLINE
 bool
-glms_vec3_isinf(vec3s v) {
+glms_vec3_(isinf)(vec3s v) {
   return glm_vec3_isinf(v.raw);
 }
 
@@ -179,7 +182,7 @@ glms_vec3_isinf(vec3s v) {
  */
 CGLM_INLINE
 bool
-glms_vec3_isvalid(vec3s v) {
+glms_vec3_(isvalid)(vec3s v) {
   return glm_vec3_isvalid(v.raw);
 }
 
@@ -193,7 +196,7 @@ glms_vec3_isvalid(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_sign(vec3s v) {
+glms_vec3_(sign)(vec3s v) {
   vec3s r;
   glm_vec3_sign(v.raw, r.raw);
   return r;
@@ -207,7 +210,7 @@ glms_vec3_sign(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_abs(vec3s v) {
+glms_vec3_(abs)(vec3s v) {
   vec3s r;
   glm_vec3_abs(v.raw, r.raw);
   return r;
@@ -221,7 +224,7 @@ glms_vec3_abs(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_fract(vec3s v) {
+glms_vec3_(fract)(vec3s v) {
   vec3s r;
   glm_vec3_fract(v.raw, r.raw);
   return r;
@@ -236,7 +239,7 @@ glms_vec3_fract(vec3s v) {
  */
 CGLM_INLINE
 float
-glms_vec3_hadd(vec3s v) {
+glms_vec3_(hadd)(vec3s v) {
   return glm_vec3_hadd(v.raw);
 }
 
@@ -248,7 +251,7 @@ glms_vec3_hadd(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_sqrt(vec3s v) {
+glms_vec3_(sqrt)(vec3s v) {
   vec3s r;
   glm_vec3_sqrt(v.raw, r.raw);
   return r;

--- a/include/cglm/struct/vec3.h
+++ b/include/cglm/struct/vec3.h
@@ -119,7 +119,7 @@ glms_vec3(vec4s v4) {
  */
 CGLM_INLINE
 void
-glms_vec3_pack(vec3s dst[], vec3 src[], size_t len) {
+glms_vec3_(pack)(vec3s dst[], vec3 src[], size_t len) {
   size_t i;
 
   for (i = 0; i < len; i++) {
@@ -136,7 +136,7 @@ glms_vec3_pack(vec3s dst[], vec3 src[], size_t len) {
  */
 CGLM_INLINE
 void
-glms_vec3_unpack(vec3 dst[], vec3s src[], size_t len) {
+glms_vec3_(unpack)(vec3 dst[], vec3s src[], size_t len) {
   size_t i;
 
   for (i = 0; i < len; i++) {
@@ -151,7 +151,7 @@ glms_vec3_unpack(vec3 dst[], vec3s src[], size_t len) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_zero(void) {
+glms_vec3_(zero)(void) {
   vec3s r;
   glm_vec3_zero(r.raw);
   return r;
@@ -164,7 +164,7 @@ glms_vec3_zero(void) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_one(void) {
+glms_vec3_(one)(void) {
   vec3s r;
   glm_vec3_one(r.raw);
   return r;
@@ -180,7 +180,7 @@ glms_vec3_one(void) {
  */
 CGLM_INLINE
 float
-glms_vec3_dot(vec3s a, vec3s b) {
+glms_vec3_(dot)(vec3s a, vec3s b) {
   return glm_vec3_dot(a.raw, b.raw);
 }
 
@@ -197,7 +197,7 @@ glms_vec3_dot(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 float
-glms_vec3_norm2(vec3s v) {
+glms_vec3_(norm2)(vec3s v) {
   return glm_vec3_norm2(v.raw);
 }
 
@@ -210,7 +210,7 @@ glms_vec3_norm2(vec3s v) {
  */
 CGLM_INLINE
 float
-glms_vec3_norm(vec3s v) {
+glms_vec3_(norm)(vec3s v) {
   return glm_vec3_norm(v.raw);
 }
 
@@ -230,7 +230,7 @@ glms_vec3_norm(vec3s v) {
  */
 CGLM_INLINE
 float
-glms_vec3_norm_one(vec3s v) {
+glms_vec3_(norm_one)(vec3s v) {
   return glm_vec3_norm_one(v.raw);
 }
 
@@ -249,7 +249,7 @@ glms_vec3_norm_one(vec3s v) {
  */
 CGLM_INLINE
 float
-glms_vec3_norm_inf(vec3s v) {
+glms_vec3_(norm_inf)(vec3s v) {
   return glm_vec3_norm_inf(v.raw);
 }
 
@@ -262,7 +262,7 @@ glms_vec3_norm_inf(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_add(vec3s a, vec3s b) {
+glms_vec3_(add)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_add(a.raw, b.raw, r.raw);
   return r;
@@ -277,7 +277,7 @@ glms_vec3_add(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_adds(vec3s a, float s) {
+glms_vec3_(adds)(vec3s a, float s) {
   vec3s r;
   glm_vec3_adds(a.raw, s, r.raw);
   return r;
@@ -292,7 +292,7 @@ glms_vec3_adds(vec3s a, float s) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_sub(vec3s a, vec3s b) {
+glms_vec3_(sub)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_sub(a.raw, b.raw, r.raw);
   return r;
@@ -307,7 +307,7 @@ glms_vec3_sub(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_subs(vec3s a, float s) {
+glms_vec3_(subs)(vec3s a, float s) {
   vec3s r;
   glm_vec3_subs(a.raw, s, r.raw);
   return r;
@@ -322,7 +322,7 @@ glms_vec3_subs(vec3s a, float s) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_mul(vec3s a, vec3s b) {
+glms_vec3_(mul)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_mul(a.raw, b.raw, r.raw);
   return r;
@@ -337,7 +337,7 @@ glms_vec3_mul(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_scale(vec3s v, float s) {
+glms_vec3_(scale)(vec3s v, float s) {
   vec3s r;
   glm_vec3_scale(v.raw, s, r.raw);
   return r;
@@ -352,7 +352,7 @@ glms_vec3_scale(vec3s v, float s) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_scale_as(vec3s v, float s) {
+glms_vec3_(scale_as)(vec3s v, float s) {
   vec3s r;
   glm_vec3_scale_as(v.raw, s, r.raw);
   return r;
@@ -367,7 +367,7 @@ glms_vec3_scale_as(vec3s v, float s) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_div(vec3s a, vec3s b) {
+glms_vec3_(div)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_div(a.raw, b.raw, r.raw);
   return r;
@@ -382,7 +382,7 @@ glms_vec3_div(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_divs(vec3s a, float s) {
+glms_vec3_(divs)(vec3s a, float s) {
   vec3s r;
   glm_vec3_divs(a.raw, s, r.raw);
   return r;
@@ -399,7 +399,7 @@ glms_vec3_divs(vec3s a, float s) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_addadd(vec3s a, vec3s b, vec3s dest) {
+glms_vec3_(addadd)(vec3s a, vec3s b, vec3s dest) {
   glm_vec3_addadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -415,7 +415,7 @@ glms_vec3_addadd(vec3s a, vec3s b, vec3s dest) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_subadd(vec3s a, vec3s b, vec3s dest) {
+glms_vec3_(subadd)(vec3s a, vec3s b, vec3s dest) {
   glm_vec3_subadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -431,7 +431,7 @@ glms_vec3_subadd(vec3s a, vec3s b, vec3s dest) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_muladd(vec3s a, vec3s b, vec3s dest) {
+glms_vec3_(muladd)(vec3s a, vec3s b, vec3s dest) {
   glm_vec3_muladd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -447,7 +447,7 @@ glms_vec3_muladd(vec3s a, vec3s b, vec3s dest) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_muladds(vec3s a, float s, vec3s dest) {
+glms_vec3_(muladds)(vec3s a, float s, vec3s dest) {
   glm_vec3_muladds(a.raw, s, dest.raw);
   return dest;
 }
@@ -463,7 +463,7 @@ glms_vec3_muladds(vec3s a, float s, vec3s dest) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_maxadd(vec3s a, vec3s b, vec3s dest) {
+glms_vec3_(maxadd)(vec3s a, vec3s b, vec3s dest) {
   glm_vec3_maxadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -479,7 +479,7 @@ glms_vec3_maxadd(vec3s a, vec3s b, vec3s dest) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_minadd(vec3s a, vec3s b, vec3s dest) {
+glms_vec3_(minadd)(vec3s a, vec3s b, vec3s dest) {
   glm_vec3_minadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -492,7 +492,7 @@ glms_vec3_minadd(vec3s a, vec3s b, vec3s dest) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_flipsign(vec3s v) {
+glms_vec3_(flipsign)(vec3s v) {
   glm_vec3_flipsign(v.raw);
   return v;
 }
@@ -505,7 +505,7 @@ glms_vec3_flipsign(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_negate(vec3s v) {
+glms_vec3_(negate)(vec3s v) {
   glm_vec3_negate(v.raw);
   return v;
 }
@@ -518,7 +518,7 @@ glms_vec3_negate(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_normalize(vec3s v) {
+glms_vec3_(normalize)(vec3s v) {
   glm_vec3_normalize(v.raw);
   return v;
 }
@@ -532,7 +532,7 @@ glms_vec3_normalize(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_cross(vec3s a, vec3s b) {
+glms_vec3_(cross)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_cross(a.raw, b.raw, r.raw);
   return r;
@@ -547,7 +547,7 @@ glms_vec3_cross(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_crossn(vec3s a, vec3s b) {
+glms_vec3_(crossn)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_crossn(a.raw, b.raw, r.raw);
   return r;
@@ -563,7 +563,7 @@ glms_vec3_crossn(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 float
-glms_vec3_angle(vec3s a, vec3s b) {
+glms_vec3_(angle)(vec3s a, vec3s b) {
   return glm_vec3_angle(a.raw, b.raw);
 }
 
@@ -577,7 +577,7 @@ glms_vec3_angle(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_rotate(vec3s v, float angle, vec3s axis) {
+glms_vec3_(rotate)(vec3s v, float angle, vec3s axis) {
   glm_vec3_rotate(v.raw, angle, axis.raw);
   return v;
 }
@@ -597,7 +597,7 @@ glms_vec3_rotate(vec3s v, float angle, vec3s axis) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_rotate_m4(mat4s m, vec3s v) {
+glms_vec3_(rotate_m4)(mat4s m, vec3s v) {
   vec3s r;
   glm_vec3_rotate_m4(m.raw, v.raw, r.raw);
   return r;
@@ -612,7 +612,7 @@ glms_vec3_rotate_m4(mat4s m, vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_rotate_m3(mat3s m, vec3s v) {
+glms_vec3_(rotate_m3)(mat3s m, vec3s v) {
   vec3s r;
   glm_vec3_rotate_m3(m.raw, v.raw, r.raw);
   return r;
@@ -627,7 +627,7 @@ glms_vec3_rotate_m3(mat3s m, vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_proj(vec3s a, vec3s b) {
+glms_vec3_(proj)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_proj(a.raw, b.raw, r.raw);
   return r;
@@ -642,7 +642,7 @@ glms_vec3_proj(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_center(vec3s a, vec3s b) {
+glms_vec3_(center)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_center(a.raw, b.raw, r.raw);
   return r;
@@ -657,7 +657,7 @@ glms_vec3_center(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 float
-glms_vec3_distance(vec3s a, vec3s b) {
+glms_vec3_(distance)(vec3s a, vec3s b) {
   return glm_vec3_distance(a.raw, b.raw);
 }
 
@@ -670,7 +670,7 @@ glms_vec3_distance(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 float
-glms_vec3_distance2(vec3s a, vec3s b) {
+glms_vec3_(distance2)(vec3s a, vec3s b) {
   return glm_vec3_distance2(a.raw, b.raw);
 }
 
@@ -683,7 +683,7 @@ glms_vec3_distance2(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_maxv(vec3s a, vec3s b) {
+glms_vec3_(maxv)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_maxv(a.raw, b.raw, r.raw);
   return r;
@@ -698,7 +698,7 @@ glms_vec3_maxv(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_minv(vec3s a, vec3s b) {
+glms_vec3_(minv)(vec3s a, vec3s b) {
   vec3s r;
   glm_vec3_minv(a.raw, b.raw, r.raw);
   return r;
@@ -712,7 +712,7 @@ glms_vec3_minv(vec3s a, vec3s b) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_ortho(vec3s v) {
+glms_vec3_(ortho)(vec3s v) {
   vec3s r;
   glm_vec3_ortho(v.raw, r.raw);
   return r;
@@ -728,7 +728,7 @@ glms_vec3_ortho(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_clamp(vec3s v, float minVal, float maxVal) {
+glms_vec3_(clamp)(vec3s v, float minVal, float maxVal) {
   glm_vec3_clamp(v.raw, minVal, maxVal);
   return v;
 }
@@ -745,7 +745,7 @@ glms_vec3_clamp(vec3s v, float minVal, float maxVal) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_lerp(vec3s from, vec3s to, float t) {
+glms_vec3_(lerp)(vec3s from, vec3s to, float t) {
   vec3s r;
   glm_vec3_lerp(from.raw, to.raw, t, r.raw);
   return r;
@@ -763,7 +763,7 @@ glms_vec3_lerp(vec3s from, vec3s to, float t) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_lerpc(vec3s from, vec3s to, float t) {
+glms_vec3_(lerpc)(vec3s from, vec3s to, float t) {
   vec3s r;
   glm_vec3_lerpc(from.raw, to.raw, t, r.raw);
   return r;
@@ -781,7 +781,7 @@ glms_vec3_lerpc(vec3s from, vec3s to, float t) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_mix(vec3s from, vec3s to, float t) {
+glms_vec3_(mix)(vec3s from, vec3s to, float t) {
   vec3s r;
   glm_vec3_mix(from.raw, to.raw, t, r.raw);
   return r;
@@ -799,7 +799,7 @@ glms_vec3_mix(vec3s from, vec3s to, float t) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_mixc(vec3s from, vec3s to, float t) {
+glms_vec3_(mixc)(vec3s from, vec3s to, float t) {
   vec3s r;
   glm_vec3_mixc(from.raw, to.raw, t, r.raw);
   return r;
@@ -814,7 +814,7 @@ glms_vec3_mixc(vec3s from, vec3s to, float t) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_step_uni(float edge, vec3s x) {
+glms_vec3_(step_uni)(float edge, vec3s x) {
   vec3s r;
   glm_vec3_step_uni(edge, x.raw, r.raw);
   return r;
@@ -829,7 +829,7 @@ glms_vec3_step_uni(float edge, vec3s x) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_step(vec3s edge, vec3s x) {
+glms_vec3_(step)(vec3s edge, vec3s x) {
   vec3s r;
   glm_vec3_step(edge.raw, x.raw, r.raw);
   return r;
@@ -845,7 +845,7 @@ glms_vec3_step(vec3s edge, vec3s x) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_smoothstep_uni(float edge0, float edge1, vec3s x) {
+glms_vec3_(smoothstep_uni)(float edge0, float edge1, vec3s x) {
   vec3s r;
   glm_vec3_smoothstep_uni(edge0, edge1, x.raw, r.raw);
   return r;
@@ -861,7 +861,7 @@ glms_vec3_smoothstep_uni(float edge0, float edge1, vec3s x) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_smoothstep(vec3s edge0, vec3s edge1, vec3s x) {
+glms_vec3_(smoothstep)(vec3s edge0, vec3s edge1, vec3s x) {
   vec3s r;
   glm_vec3_smoothstep(edge0.raw, edge1.raw, x.raw, r.raw);
   return r;
@@ -879,7 +879,7 @@ glms_vec3_smoothstep(vec3s edge0, vec3s edge1, vec3s x) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_smoothinterp(vec3s from, vec3s to, float t) {
+glms_vec3_(smoothinterp)(vec3s from, vec3s to, float t) {
   vec3s r;
   glm_vec3_smoothinterp(from.raw, to.raw, t, r.raw);
   return r;
@@ -897,7 +897,7 @@ glms_vec3_smoothinterp(vec3s from, vec3s to, float t) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_smoothinterpc(vec3s from, vec3s to, float t) {
+glms_vec3_(smoothinterpc)(vec3s from, vec3s to, float t) {
   vec3s r;
   glm_vec3_smoothinterpc(from.raw, to.raw, t, r.raw);
   return r;
@@ -961,7 +961,7 @@ glms_normalize(vec3s v) {
  */
 CGLM_INLINE
 vec3s
-glms_vec3_swizzle(vec3s v, int mask) {
+glms_vec3_(swizzle)(vec3s v, int mask) {
   vec3s dest;
   glm_vec3_swizzle(v.raw, mask, dest.raw);
   return dest;

--- a/include/cglm/struct/vec4-ext.h
+++ b/include/cglm/struct/vec4-ext.h
@@ -38,6 +38,9 @@
 #include "../util.h"
 #include "../vec4-ext.h"
 
+/* api definition */
+#define glms_vec4_(NAME) CGLM_STRUCTAPI(vec4, NAME)
+
 /*!
  * @brief fill a vector with specified value
  *
@@ -46,7 +49,7 @@
  */
 CGLM_INLINE
 vec4s
-glms_vec4_broadcast(float val) {
+glms_vec4_(broadcast)(float val) {
   vec4s r;
   glm_vec4_broadcast(val, r.raw);
   return r;
@@ -60,7 +63,7 @@ glms_vec4_broadcast(float val) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_fill(float val) {
+glms_vec4_(fill)(float val) {
   vec4s r;
   glm_vec4_fill(r.raw, val);
   return r;
@@ -74,7 +77,7 @@ glms_vec4_fill(float val) {
  */
 CGLM_INLINE
 bool
-glms_vec4_eq(vec4s v, float val) {
+glms_vec4_(eq)(vec4s v, float val) {
   return glm_vec4_eq(v.raw, val);
 }
 
@@ -86,7 +89,7 @@ glms_vec4_eq(vec4s v, float val) {
  */
 CGLM_INLINE
 bool
-glms_vec4_eq_eps(vec4s v, float val) {
+glms_vec4_(eq_eps)(vec4s v, float val) {
   return glm_vec4_eq_eps(v.raw, val);
 }
 
@@ -97,7 +100,7 @@ glms_vec4_eq_eps(vec4s v, float val) {
  */
 CGLM_INLINE
 bool
-glms_vec4_eq_all(vec4s v) {
+glms_vec4_(eq_all)(vec4s v) {
   return glm_vec4_eq_all(v.raw);
 }
 
@@ -109,7 +112,7 @@ glms_vec4_eq_all(vec4s v) {
  */
 CGLM_INLINE
 bool
-glms_vec4_eqv(vec4s a, vec4s b) {
+glms_vec4_(eqv)(vec4s a, vec4s b) {
   return glm_vec4_eqv(a.raw, b.raw);
 }
 
@@ -121,7 +124,7 @@ glms_vec4_eqv(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 bool
-glms_vec4_eqv_eps(vec4s a, vec4s b) {
+glms_vec4_(eqv_eps)(vec4s a, vec4s b) {
   return glm_vec4_eqv_eps(a.raw, b.raw);
 }
 
@@ -132,7 +135,7 @@ glms_vec4_eqv_eps(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 float
-glms_vec4_max(vec4s v) {
+glms_vec4_(max)(vec4s v) {
   return glm_vec4_max(v.raw);
 }
 
@@ -143,7 +146,7 @@ glms_vec4_max(vec4s v) {
  */
 CGLM_INLINE
 float
-glms_vec4_min(vec4s v) {
+glms_vec4_(min)(vec4s v) {
   return glm_vec4_min(v.raw);
 }
 
@@ -155,7 +158,7 @@ glms_vec4_min(vec4s v) {
  */
 CGLM_INLINE
 bool
-glms_vec4_isnan(vec4s v) {
+glms_vec4_(isnan)(vec4s v) {
   return glm_vec4_isnan(v.raw);
 }
 
@@ -167,7 +170,7 @@ glms_vec4_isnan(vec4s v) {
  */
 CGLM_INLINE
 bool
-glms_vec4_isinf(vec4s v) {
+glms_vec4_(isinf)(vec4s v) {
   return glm_vec4_isinf(v.raw);
 }
 
@@ -179,7 +182,7 @@ glms_vec4_isinf(vec4s v) {
  */
 CGLM_INLINE
 bool
-glms_vec4_isvalid(vec4s v) {
+glms_vec4_(isvalid)(vec4s v) {
   return glm_vec4_isvalid(v.raw);
 }
 
@@ -193,7 +196,7 @@ glms_vec4_isvalid(vec4s v) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_sign(vec4s v) {
+glms_vec4_(sign)(vec4s v) {
   vec4s r;
   glm_vec4_sign(v.raw, r.raw);
   return r;
@@ -207,7 +210,7 @@ glms_vec4_sign(vec4s v) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_abs(vec4s v) {
+glms_vec4_(abs)(vec4s v) {
   vec4s r;
   glm_vec4_abs(v.raw, r.raw);
   return r;
@@ -221,7 +224,7 @@ glms_vec4_abs(vec4s v) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_fract(vec4s v) {
+glms_vec4_(fract)(vec4s v) {
   vec4s r;
   glm_vec4_fract(v.raw, r.raw);
   return r;
@@ -236,7 +239,7 @@ glms_vec4_fract(vec4s v) {
  */
 CGLM_INLINE
 float
-glms_vec4_hadd(vec4s v) {
+glms_vec4_(hadd)(vec4s v) {
   return glm_vec4_hadd(v.raw);
 }
 
@@ -248,7 +251,7 @@ glms_vec4_hadd(vec4s v) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_sqrt(vec4s v) {
+glms_vec4_(sqrt)(vec4s v) {
   vec4s r;
   glm_vec4_sqrt(v.raw, r.raw);
   return r;

--- a/include/cglm/struct/vec4.h
+++ b/include/cglm/struct/vec4.h
@@ -103,7 +103,7 @@ glms_vec4(vec3s v3, float last) {
  */
 CGLM_INLINE
 vec3s
-glms_vec4_copy3(vec4s v) {
+glms_vec4_(copy3)(vec4s v) {
   vec3s r;
   glm_vec4_copy3(v.raw, r.raw);
   return r;
@@ -117,7 +117,7 @@ glms_vec4_copy3(vec4s v) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_copy(vec4s v) {
+glms_vec4_(copy)(vec4s v) {
   vec4s r;
   glm_vec4_copy(v.raw, r.raw);
   return r;
@@ -133,7 +133,7 @@ glms_vec4_copy(vec4s v) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_ucopy(vec4s v) {
+glms_vec4_(ucopy)(vec4s v) {
   vec4s r;
   glm_vec4_ucopy(v.raw, r.raw);
   return r;
@@ -148,7 +148,7 @@ glms_vec4_ucopy(vec4s v) {
  */
 CGLM_INLINE
 void
-glms_vec4_pack(vec4s dst[], vec4 src[], size_t len) {
+glms_vec4_(pack)(vec4s dst[], vec4 src[], size_t len) {
   size_t i;
 
   for (i = 0; i < len; i++) {
@@ -165,7 +165,7 @@ glms_vec4_pack(vec4s dst[], vec4 src[], size_t len) {
  */
 CGLM_INLINE
 void
-glms_vec4_unpack(vec4 dst[], vec4s src[], size_t len) {
+glms_vec4_(unpack)(vec4 dst[], vec4s src[], size_t len) {
   size_t i;
 
   for (i = 0; i < len; i++) {
@@ -180,7 +180,7 @@ glms_vec4_unpack(vec4 dst[], vec4s src[], size_t len) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_zero(void) {
+glms_vec4_(zero)(void) {
   vec4s r;
   glm_vec4_zero(r.raw);
   return r;
@@ -193,7 +193,7 @@ glms_vec4_zero(void) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_one(void) {
+glms_vec4_(one)(void) {
   vec4s r;
   glm_vec4_one(r.raw);
   return r;
@@ -209,7 +209,7 @@ glms_vec4_one(void) {
  */
 CGLM_INLINE
 float
-glms_vec4_dot(vec4s a, vec4s b) {
+glms_vec4_(dot)(vec4s a, vec4s b) {
   return glm_vec4_dot(a.raw, b.raw);
 }
 
@@ -226,7 +226,7 @@ glms_vec4_dot(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 float
-glms_vec4_norm2(vec4s v) {
+glms_vec4_(norm2)(vec4s v) {
   return glm_vec4_norm2(v.raw);
 }
 
@@ -239,7 +239,7 @@ glms_vec4_norm2(vec4s v) {
  */
 CGLM_INLINE
 float
-glms_vec4_norm(vec4s v) {
+glms_vec4_(norm)(vec4s v) {
   return glm_vec4_norm(v.raw);
 }
 
@@ -259,7 +259,7 @@ glms_vec4_norm(vec4s v) {
  */
 CGLM_INLINE
 float
-glms_vec4_norm_one(vec4s v) {
+glms_vec4_(norm_one)(vec4s v) {
   return glm_vec4_norm_one(v.raw);
 }
 
@@ -278,7 +278,7 @@ glms_vec4_norm_one(vec4s v) {
  */
 CGLM_INLINE
 float
-glms_vec4_norm_inf(vec4s v) {
+glms_vec4_(norm_inf)(vec4s v) {
   return glm_vec4_norm_inf(v.raw);
 }
 
@@ -291,7 +291,7 @@ glms_vec4_norm_inf(vec4s v) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_add(vec4s a, vec4s b) {
+glms_vec4_(add)(vec4s a, vec4s b) {
   vec4s r;
   glm_vec4_add(a.raw, b.raw, r.raw);
   return r;
@@ -306,7 +306,7 @@ glms_vec4_add(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_adds(vec4s v, float s) {
+glms_vec4_(adds)(vec4s v, float s) {
   vec4s r;
   glm_vec4_adds(v.raw, s, r.raw);
   return r;
@@ -321,7 +321,7 @@ glms_vec4_adds(vec4s v, float s) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_sub(vec4s a, vec4s b) {
+glms_vec4_(sub)(vec4s a, vec4s b) {
   vec4s r;
   glm_vec4_sub(a.raw, b.raw, r.raw);
   return r;
@@ -336,7 +336,7 @@ glms_vec4_sub(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_subs(vec4s v, float s) {
+glms_vec4_(subs)(vec4s v, float s) {
   vec4s r;
   glm_vec4_subs(v.raw, s, r.raw);
   return r;
@@ -351,7 +351,7 @@ glms_vec4_subs(vec4s v, float s) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_mul(vec4s a, vec4s b) {
+glms_vec4_(mul)(vec4s a, vec4s b) {
   vec4s r;
   glm_vec4_mul(a.raw, b.raw, r.raw);
   return r;
@@ -366,7 +366,7 @@ glms_vec4_mul(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_scale(vec4s v, float s) {
+glms_vec4_(scale)(vec4s v, float s) {
   vec4s r;
   glm_vec4_scale(v.raw, s, r.raw);
   return r;
@@ -381,7 +381,7 @@ glms_vec4_scale(vec4s v, float s) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_scale_as(vec4s v, float s) {
+glms_vec4_(scale_as)(vec4s v, float s) {
   vec4s r;
   glm_vec4_scale_as(v.raw, s, r.raw);
   return r;
@@ -396,7 +396,7 @@ glms_vec4_scale_as(vec4s v, float s) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_div(vec4s a, vec4s b) {
+glms_vec4_(div)(vec4s a, vec4s b) {
   vec4s r;
   glm_vec4_div(a.raw, b.raw, r.raw);
   return r;
@@ -411,7 +411,7 @@ glms_vec4_div(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_divs(vec4s v, float s) {
+glms_vec4_(divs)(vec4s v, float s) {
   vec4s r;
   glm_vec4_divs(v.raw, s, r.raw);
   return r;
@@ -428,7 +428,7 @@ glms_vec4_divs(vec4s v, float s) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_addadd(vec4s a, vec4s b, vec4s dest) {
+glms_vec4_(addadd)(vec4s a, vec4s b, vec4s dest) {
   glm_vec4_addadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -444,7 +444,7 @@ glms_vec4_addadd(vec4s a, vec4s b, vec4s dest) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_subadd(vec4s a, vec4s b, vec4s dest) {
+glms_vec4_(subadd)(vec4s a, vec4s b, vec4s dest) {
   glm_vec4_subadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -460,7 +460,7 @@ glms_vec4_subadd(vec4s a, vec4s b, vec4s dest) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_muladd(vec4s a, vec4s b, vec4s dest) {
+glms_vec4_(muladd)(vec4s a, vec4s b, vec4s dest) {
   glm_vec4_muladd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -476,7 +476,7 @@ glms_vec4_muladd(vec4s a, vec4s b, vec4s dest) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_muladds(vec4s a, float s, vec4s dest) {
+glms_vec4_(muladds)(vec4s a, float s, vec4s dest) {
   glm_vec4_muladds(a.raw, s, dest.raw);
   return dest;
 }
@@ -492,7 +492,7 @@ glms_vec4_muladds(vec4s a, float s, vec4s dest) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_maxadd(vec4s a, vec4s b, vec4s dest) {
+glms_vec4_(maxadd)(vec4s a, vec4s b, vec4s dest) {
   glm_vec4_maxadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -508,7 +508,7 @@ glms_vec4_maxadd(vec4s a, vec4s b, vec4s dest) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_minadd(vec4s a, vec4s b, vec4s dest) {
+glms_vec4_(minadd)(vec4s a, vec4s b, vec4s dest) {
   glm_vec4_minadd(a.raw, b.raw, dest.raw);
   return dest;
 }
@@ -521,7 +521,7 @@ glms_vec4_minadd(vec4s a, vec4s b, vec4s dest) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_negate(vec4s v) {
+glms_vec4_(negate)(vec4s v) {
   glm_vec4_negate(v.raw);
   return v;
 }
@@ -534,7 +534,7 @@ glms_vec4_negate(vec4s v) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_normalize(vec4s v) {
+glms_vec4_(normalize)(vec4s v) {
   glm_vec4_normalize(v.raw);
   return v;
 }
@@ -548,7 +548,7 @@ glms_vec4_normalize(vec4s v) {
  */
 CGLM_INLINE
 float
-glms_vec4_distance(vec4s a, vec4s b) {
+glms_vec4_(distance)(vec4s a, vec4s b) {
   return glm_vec4_distance(a.raw, b.raw);
 }
 
@@ -561,7 +561,7 @@ glms_vec4_distance(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 float
-glms_vec4_distance2(vec4s a, vec4s b) {
+glms_vec4_(distance2)(vec4s a, vec4s b) {
   return glm_vec4_distance2(a.raw, b.raw);
 }
 
@@ -574,7 +574,7 @@ glms_vec4_distance2(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_maxv(vec4s a, vec4s b) {
+glms_vec4_(maxv)(vec4s a, vec4s b) {
   vec4s r;
   glm_vec4_maxv(a.raw, b.raw, r.raw);
   return r;
@@ -589,7 +589,7 @@ glms_vec4_maxv(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_minv(vec4s a, vec4s b) {
+glms_vec4_(minv)(vec4s a, vec4s b) {
   vec4s r;
   glm_vec4_minv(a.raw, b.raw, r.raw);
   return r;
@@ -605,7 +605,7 @@ glms_vec4_minv(vec4s a, vec4s b) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_clamp(vec4s v, float minVal, float maxVal) {
+glms_vec4_(clamp)(vec4s v, float minVal, float maxVal) {
   glm_vec4_clamp(v.raw, minVal, maxVal);
   return v;
 }
@@ -622,7 +622,7 @@ glms_vec4_clamp(vec4s v, float minVal, float maxVal) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_lerp(vec4s from, vec4s to, float t) {
+glms_vec4_(lerp)(vec4s from, vec4s to, float t) {
   vec4s r;
   glm_vec4_lerp(from.raw, to.raw, t, r.raw);
   return r;
@@ -640,7 +640,7 @@ glms_vec4_lerp(vec4s from, vec4s to, float t) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_lerpc(vec4s from, vec4s to, float t) {
+glms_vec4_(lerpc)(vec4s from, vec4s to, float t) {
   vec4s r;
   glm_vec4_lerpc(from.raw, to.raw, t, r.raw);
   return r;
@@ -658,7 +658,7 @@ glms_vec4_lerpc(vec4s from, vec4s to, float t) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_mix(vec4s from, vec4s to, float t) {
+glms_vec4_(mix)(vec4s from, vec4s to, float t) {
   vec4s r;
   glm_vec4_mix(from.raw, to.raw, t, r.raw);
   return r;
@@ -676,7 +676,7 @@ glms_vec4_mix(vec4s from, vec4s to, float t) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_mixc(vec4s from, vec4s to, float t) {
+glms_vec4_(mixc)(vec4s from, vec4s to, float t) {
   vec4s r;
   glm_vec4_mixc(from.raw, to.raw, t, r.raw);
   return r;
@@ -691,7 +691,7 @@ glms_vec4_mixc(vec4s from, vec4s to, float t) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_step_uni(float edge, vec4s x) {
+glms_vec4_(step_uni)(float edge, vec4s x) {
   vec4s r;
   glm_vec4_step_uni(edge, x.raw, r.raw);
   return r;
@@ -706,7 +706,7 @@ glms_vec4_step_uni(float edge, vec4s x) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_step(vec4s edge, vec4s x) {
+glms_vec4_(step)(vec4s edge, vec4s x) {
   vec4s r;
   glm_vec4_step(edge.raw, x.raw, r.raw);
   return r;
@@ -722,7 +722,7 @@ glms_vec4_step(vec4s edge, vec4s x) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_smoothstep_uni(float edge0, float edge1, vec4s x) {
+glms_vec4_(smoothstep_uni)(float edge0, float edge1, vec4s x) {
   vec4s r;
   glm_vec4_smoothstep_uni(edge0, edge1, x.raw, r.raw);
   return r;
@@ -738,7 +738,7 @@ glms_vec4_smoothstep_uni(float edge0, float edge1, vec4s x) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_smoothstep(vec4s edge0, vec4s edge1, vec4s x) {
+glms_vec4_(smoothstep)(vec4s edge0, vec4s edge1, vec4s x) {
   vec4s r;
   glm_vec4_smoothstep(edge0.raw, edge1.raw, x.raw, r.raw);
   return r;
@@ -756,7 +756,7 @@ glms_vec4_smoothstep(vec4s edge0, vec4s edge1, vec4s x) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_smoothinterp(vec4s from, vec4s to, float t) {
+glms_vec4_(smoothinterp)(vec4s from, vec4s to, float t) {
   vec4s r;
   glm_vec4_smoothinterp(from.raw, to.raw, t, r.raw);
   return r;
@@ -774,7 +774,7 @@ glms_vec4_smoothinterp(vec4s from, vec4s to, float t) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_smoothinterpc(vec4s from, vec4s to, float t) {
+glms_vec4_(smoothinterpc)(vec4s from, vec4s to, float t) {
   vec4s r;
   glm_vec4_smoothinterpc(from.raw, to.raw, t, r.raw);
   return r;
@@ -788,7 +788,7 @@ glms_vec4_smoothinterpc(vec4s from, vec4s to, float t) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_cubic(float s) {
+glms_vec4_(cubic)(float s) {
   vec4s r;
   glm_vec4_cubic(s, r.raw);
   return r;
@@ -805,7 +805,7 @@ glms_vec4_cubic(float s) {
  */
 CGLM_INLINE
 vec4s
-glms_vec4_swizzle(vec4s v, int mask) {
+glms_vec4_(swizzle)(vec4s v, int mask) {
   vec4s dest;
   glm_vec4_swizzle(v.raw, mask, dest.raw);
   return dest;


### PR DESCRIPTION
related issue: https://github.com/recp/cglm/issues/197

Provide option to omit struct api namespace e.g. `glms_` and an option to add `s` suffix e.g. mat4s_mul if preferred. Now **cglm** makes things more flexible & readable for struct api

now we can omit glms_ like:

```C
/* previous / default */
return glms_vec3_normalized(glms_vec3_cross(a, b));

/* this must be defined before cglm inc especially common.h */
#define CGLM_OMIT_NS_FROM_STRUCT_API /* or define at compiler settings */

/* new!! */
return vec3_normalized(vec3_cross(a, b));

/* if CGLM_STRUCT_API_NAME_SUFFIX is defined as `s`  */
return vec3s_normalized(vec3s_cross(a, b));
```

new options:

- `CGLM_OMIT_NS_FROM_STRUCT_API`, omits CGLM_STRUCT_API_NS (glms_) namespace  completely if there is sub namespace e.g mat4_, vec4_ ... **DEFAULT** is not defined
- `CGLM_STRUCT_API_NS`: define name space for struct api,  **DEFAULT** is `glms`
- `CGLM_STRUCT_API_NAME_SUFFIX`: define name suffix,  **DEFAULT** is empty e.g `defining it as #define CGLM_STRUCT_API_NAME_SUFFIX  s` will add `s` suffix to `mat4_mul -> mat4s_mul`

Previous func declarations: 

```C
CGLM_INLINE
mat4s
glms_mat4_ucopy(mat4s mat) { ... }

CGLM_INLINE
mat4s
glms_mat4_mul(mat4s m1, mat4s m2) {
  mat4s r;
  glm_mat4_mul(m1.raw, m2.raw, r.raw);
  return r;
}
```

modified version which is still readable

```C
CGLM_INLINE
mat4s
glms_mat4_(ucopy)(mat4s mat) { ... }

CGLM_INLINE
mat4s
glms_mat4_(mul)(mat4s m1, mat4s m2) {
  mat4s r;
  glm_mat4_mul(m1.raw, m2.raw, r.raw);
  return r;
}
```

I didn't surround all function my macro like:

```C
CGLM_STRUCTAPI(glms_mat4_mul(mat4s m1, mat4s m2)) { 

}
```

in current implemented version:
- compiler can highlight parameters
- function declaration is similar / identical to previous one except parenthesis
- we can add `s` suffix like  `mat4s_mul` if preferred instead of  `mat4_mul`


