### PR TITLE
wasm: replace usage of -0.f to 0x80000000

### DIFF
--- a/include/cglm/simd/wasm.h
+++ b/include/cglm/simd/wasm.h
@@ -26,6 +26,16 @@
 #define glmm_splat_z(x) glmm_splat(x, 2)
 #define glmm_splat_w(x) glmm_splat(x, 3)
 
+#define GLMM_NEGZEROf 0x80000000 /*  0x80000000 ---> -0.0f  */
+
+/* _mm_set_ps(X, Y, Z, W); */
+#define GLMM__SIGNMASKf(X, Y, Z, W) wasm_i32x4_const(X, Y, Z, W)
+
+#define glmm_float32x4_SIGNMASK_PNPN GLMM__SIGNMASKf(0, GLMM_NEGZEROf, 0, GLMM_NEGZEROf)
+#define glmm_float32x4_SIGNMASK_NPNP GLMM__SIGNMASKf(GLMM_NEGZEROf, 0, GLMM_NEGZEROf, 0)
+#define glmm_float32x4_SIGNMASK_NPPN GLMM__SIGNMASKf(GLMM_NEGZEROf, 0, 0, GLMM_NEGZEROf)
+#define glmm_float32x4_SIGNMASK_NEG wasm_i32x4_const_splat(GLMM_NEGZEROf)
+
 static inline
 glmm_128
 glmm_abs(glmm_128 x) {

--- a/include/cglm/simd/wasm/mat4.h
+++ b/include/cglm/simd/wasm/mat4.h
@@ -164,8 +164,8 @@ glm_mat4_det_wasm(mat4 mat) {
   x2 = glmm_fmadd(glmm_shuff1(r1, 2, 3, 3, 3),
                   wasm_i32x4_shuffle(x0, x1, 1, 3, 6, 6),
                   x2);
-  
-  x2 = wasm_v128_xor(x2, wasm_f32x4_const(0.f, -0.f, 0.f, -0.f));
+  /* x2 = wasm_v128_xor(x2, wasm_f32x4_const(0.f, -0.f, 0.f, -0.f)); */
+  x2 = wasm_v128_xor(x2, glmm_float32x4_SIGNMASK_PNPN);
   
   return glmm_hadd(wasm_f32x4_mul(x2, r0));
 }
@@ -178,7 +178,8 @@ glm_mat4_inv_fast_wasm(mat4 mat, mat4 dest) {
          t0, t1, t2, t3, t4, t5,
          x0, x1, x2, x3, x4, x5, x6, x7, x8, x9;
 
-  x8 = wasm_f32x4_const(0.f, -0.f, 0.f, -0.f);
+  /* x8 = wasm_f32x4_const(0.f, -0.f, 0.f, -0.f); */
+  x8 = glmm_float32x4_SIGNMASK_PNPN;
   x9 = glmm_shuff1(x8, 2, 1, 2, 1);
 
   /* 127 <- 0 */
@@ -318,7 +319,8 @@ glm_mat4_inv_wasm(mat4 mat, mat4 dest) {
          t0, t1, t2, t3, t4, t5,
          x0, x1, x2, x3, x4, x5, x6, x7, x8, x9;
 
-  x8 = wasm_f32x4_const(0.f, -0.f, 0.f, -0.f);
+  /* x8 = wasm_f32x4_const(0.f, -0.f, 0.f, -0.f); */
+  x8 = glmm_float32x4_SIGNMASK_PNPN;
   x9 = glmm_shuff1(x8, 2, 1, 2, 1);
 
   /* 127 <- 0 */

--- a/include/cglm/simd/wasm/quat.h
+++ b/include/cglm/simd/wasm/quat.h
@@ -26,7 +26,8 @@ glm_quat_mul_wasm(versor p, versor q, versor dest) {
 
   xp = glmm_load(p); /* 3 2 1 0 */
   xq = glmm_load(q);
-  x1 = wasm_f32x4_const(0.f, -0.f, 0.f, -0.f); /* TODO: _mm_set1_ss() + shuff ? */
+  /* x1 = wasm_f32x4_const(0.f, -0.f, 0.f, -0.f); */
+  x1 = glmm_float32x4_SIGNMASK_PNPN; /* TODO: _mm_set1_ss() + shuff ? */
   r  = wasm_f32x4_mul(glmm_splat_w(xp), xq);
   /* x2 = _mm_unpackhi_ps(x1, x1); */
   x2 = wasm_i32x4_shuffle(x1, x1, 2, 6, 3, 7);


### PR DESCRIPTION
Part of https://github.com/recp/cglm/pull/291

Should note that only `glmm_float32x4_SIGNMASK_PNPN` is used in wasm simd128.

This should not change the compiled output, according to [compiler explorer](https://godbolt.org/z/KjKfWzTWG)
![compiler explorer](https://user-images.githubusercontent.com/17702502/233758404-658a0f95-ab8f-462e-a66f-bac56b90d894.png)
