### PR TITLE
README: update meson option for running test

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ $ sudo ninja install # [Optional]
 c_std=c11
 buildtype=release
 default_library=shared
-enable_tests=false # to run tests: ninja test
+build_tests=true # to run tests: ninja test
 ```
 #### Use with your Meson project
 * Example:


### PR DESCRIPTION
Running on an already built build directory

```
meson configure -Denable_tests=true build/
```

Leads to

`ERROR: Unknown options: "enable_tests"`

Seems the meson option was updated