### PR TITLE
mat2: add new function glm_mat2_make

### DIFF
--- a/docs/source/mat2.rst
+++ b/docs/source/mat2.rst
@@ -32,6 +32,7 @@ Functions:
 #. :c:func:`glm_mat2_swap_col`
 #. :c:func:`glm_mat2_swap_row`
 #. :c:func:`glm_mat2_rmc`
+#. :c:func:`glm_mat2_make`
 
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -177,3 +178,13 @@ Functions documentation
 
     Returns:
         scalar value e.g. Matrix1x1
+
+.. c:function:: void glm_mat2_make(float * __restrict src, mat2 dest)
+
+    Create mat2 matrix from pointer
+
+    | NOTE: **@src** must contain 4 elements.
+
+    Parameters:
+      | *[in]*  **src**  pointer to an array of floats
+      | *[out]* **dest** destination matrix2x2

--- a/include/cglm/call/mat2.h
+++ b/include/cglm/call/mat2.h
@@ -73,6 +73,10 @@ CGLM_EXPORT
 float
 glmc_mat2_rmc(vec2 r, mat2 m, vec2 c);
 
+CGLM_EXPORT
+void
+glmc_mat2_make(float * __restrict src, mat2 dest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/cglm/mat2.h
+++ b/include/cglm/mat2.h
@@ -28,6 +28,7 @@
    CGLM_INLINE void  glm_mat2_swap_col(mat2 mat, int col1, int col2)
    CGLM_INLINE void  glm_mat2_swap_row(mat2 mat, int row1, int row2)
    CGLM_INLINE float glm_mat2_rmc(vec2 r, mat2 m, vec2 c)
+   CGLM_INLINE void  glm_mat2_make(float * restrict src, mat2 dest)
  */
 
 #ifndef cglm_mat2_h
@@ -343,6 +344,21 @@ glm_mat2_rmc(vec2 r, mat2 m, vec2 c) {
   vec2 tmp;
   glm_mat2_mulv(m, c, tmp);
   return glm_vec2_dot(r, tmp);
+}
+
+/*!
+ * @brief Create mat2 matrix from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @param[out] dest matrix
+ */
+CGLM_INLINE
+void
+glm_mat2_make(float * __restrict src, mat2 dest) {
+  dest[0][0] = src[0];
+  dest[0][1] = src[1];
+  dest[1][0] = src[2];
+  dest[1][1] = src[3];
 }
 
 #endif /* cglm_mat2_h */

--- a/include/cglm/struct/mat2.h
+++ b/include/cglm/struct/mat2.h
@@ -258,4 +258,17 @@ glms_mat2_(rmc)(vec2s r, mat2s m, vec2s c) {
   return glm_mat2_rmc(r.raw, m.raw, c.raw);
 }
 
+/*!
+ * @brief Create mat2 matrix from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @param[out] dest matrix
+ */
+CGLM_INLINE
+mat2s
+glms_mat2_(make)(float * __restrict src, mat2s dest) {
+  glm_mat2_make(src, dest.raw);
+  return dest;
+}
+
 #endif /* cglms_mat2_h */

--- a/src/mat2.c
+++ b/src/mat2.c
@@ -97,3 +97,9 @@ float
 glmc_mat2_rmc(vec2 r, mat2 m, vec2 c) {
   return glm_mat2_rmc(r, m, c);
 }
+
+CGLM_EXPORT
+void
+glmc_mat2_make(float * __restrict src, mat2 dest) {
+  glm_mat2_make(src, dest);
+}

--- a/test/src/test_mat2.h
+++ b/test/src/test_mat2.h
@@ -8,6 +8,7 @@
 #include "test_common.h"
 
 #define A_MATRIX2x2 {{1,2},{5,6}}
+#define MAT2_ARRAY {1, 5, 2, 7}
 
 #ifndef CGLM_TEST_MAT2_ONCE
 #define CGLM_TEST_MAT2_ONCE
@@ -279,6 +280,21 @@ TEST_IMPL(GLM_PREFIX, mat2_rmc) {
   r2 = v[0] * v1[0] + v[1] * v1[1];
 
   ASSERT(test_eq(r1, r2))
+
+  TEST_SUCCESS
+}
+
+TEST_IMPL(GLM_PREFIX, mat2_make) {
+  mat2 dest;
+  unsigned int i, j;
+  float src[4] = MAT2_ARRAY;
+
+  GLM(mat2_make)(src, dest);
+
+  for (i = 0, j = 0; i < sizeof(src) / sizeof(float); i+=2, j++) {
+    ASSERT(test_eq(dest[j][0], src[i]))
+    ASSERT(test_eq(dest[j][1], src[i+1]))
+  }
 
   TEST_SUCCESS
 }

--- a/test/tests.h
+++ b/test/tests.h
@@ -205,6 +205,7 @@ TEST_DECLARE(glm_mat2_inv)
 TEST_DECLARE(glm_mat2_swap_col)
 TEST_DECLARE(glm_mat2_swap_row)
 TEST_DECLARE(glm_mat2_rmc)
+TEST_DECLARE(glm_mat2_make)
 
 TEST_DECLARE(glmc_mat2_copy)
 TEST_DECLARE(glmc_mat2_identity)
@@ -221,6 +222,7 @@ TEST_DECLARE(glmc_mat2_inv)
 TEST_DECLARE(glmc_mat2_swap_col)
 TEST_DECLARE(glmc_mat2_swap_row)
 TEST_DECLARE(glmc_mat2_rmc)
+TEST_DECLARE(glmc_mat2_make)
 
 /* camera (incl [LR]H cross [NZ]O) */
 TEST_DECLARE(glm_perspective_lh_zo)
@@ -1046,6 +1048,7 @@ TEST_LIST {
   TEST_ENTRY(glm_mat2_swap_col)
   TEST_ENTRY(glm_mat2_swap_row)
   TEST_ENTRY(glm_mat2_rmc)
+  TEST_ENTRY(glm_mat2_make)
 
   TEST_ENTRY(glmc_mat2_copy)
   TEST_ENTRY(glmc_mat2_identity)
@@ -1062,6 +1065,7 @@ TEST_LIST {
   TEST_ENTRY(glmc_mat2_swap_col)
   TEST_ENTRY(glmc_mat2_swap_row)
   TEST_ENTRY(glmc_mat2_rmc)
+  TEST_ENTRY(glmc_mat2_make)
 
   /* camera (incl [LR]H cross [NZ]O) */
   TEST_ENTRY(glm_perspective_lh_zo)


### PR DESCRIPTION
Function takes in a 4 element float array
and converts it into a mat2 matrix.