### PR TITLE
mat3: add new function glm_mat3_make

### DIFF
--- a/docs/source/mat3.rst
+++ b/docs/source/mat3.rst
@@ -34,6 +34,7 @@ Functions:
 #. :c:func:`glm_mat3_swap_col`
 #. :c:func:`glm_mat3_swap_row`
 #. :c:func:`glm_mat3_rmc`
+#. :c:func:`glm_mat3_make`
 
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -187,3 +188,13 @@ Functions documentation
 
     Returns:
         scalar value e.g. Matrix1x1
+
+.. c:function:: void glm_mat3_make(float * __restrict src, mat3 dest)
+
+    Create mat3 matrix from pointer
+
+    | NOTE: **@src** must contain 9 elements.
+
+    Parameters:
+      | *[in]*  **src**  pointer to an array of floats
+      | *[out]* **dest** destination matrix3x3

--- a/include/cglm/call/mat3.h
+++ b/include/cglm/call/mat3.h
@@ -80,6 +80,10 @@ CGLM_EXPORT
 float
 glmc_mat3_rmc(vec3 r, mat3 m, vec3 c);
 
+CGLM_EXPORT
+void
+glmc_mat3_make(float * __restrict src, mat3 dest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/cglm/mat3.h
+++ b/include/cglm/mat3.h
@@ -30,6 +30,7 @@
    CGLM_INLINE void  glm_mat3_swap_col(mat3 mat, int col1, int col2);
    CGLM_INLINE void  glm_mat3_swap_row(mat3 mat, int row1, int row2);
    CGLM_INLINE float glm_mat3_rmc(vec3 r, mat3 m, vec3 c);
+   CGLM_INLINE void  glm_mat3_make(float * restrict src, mat3 dest);
  */
 
 #ifndef cglm_mat3_h
@@ -425,6 +426,28 @@ glm_mat3_rmc(vec3 r, mat3 m, vec3 c) {
   vec3 tmp;
   glm_mat3_mulv(m, c, tmp);
   return glm_vec3_dot(r, tmp);
+}
+
+/*!
+ * @brief Create mat3 matrix from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @param[out] dest matrix
+ */
+CGLM_INLINE
+void
+glm_mat3_make(float * __restrict src, mat3 dest) {
+  dest[0][0] = src[0];
+  dest[0][1] = src[1];
+  dest[0][2] = src[2];
+
+  dest[1][0] = src[3];
+  dest[1][1] = src[4];
+  dest[1][2] = src[5];
+
+  dest[2][0] = src[6];
+  dest[2][1] = src[7];
+  dest[2][2] = src[8];
 }
 
 #endif /* cglm_mat3_h */

--- a/include/cglm/struct/mat3.h
+++ b/include/cglm/struct/mat3.h
@@ -285,4 +285,17 @@ glms_mat3_(rmc)(vec3s r, mat3s m, vec3s c) {
   return glm_mat3_rmc(r.raw, m.raw, c.raw);
 }
 
+/*!
+ * @brief Create mat3 matrix from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @param[out] dest matrix
+ */
+CGLM_INLINE
+mat3s
+glms_mat3_(make)(float * __restrict src, mat3s dest) {
+  glm_mat3_make(src, dest.raw);
+  return dest;
+}
+
 #endif /* cglms_mat3s_h */

--- a/src/mat3.c
+++ b/src/mat3.c
@@ -103,3 +103,9 @@ float
 glmc_mat3_rmc(vec3 r, mat3 m, vec3 c) {
   return glm_mat3_rmc(r, m, c);
 }
+
+CGLM_EXPORT
+void
+glmc_mat3_make(float * __restrict src, mat3 dest) {
+  glm_mat3_make(src, dest);
+}

--- a/test/src/test_mat3.h
+++ b/test/src/test_mat3.h
@@ -8,6 +8,7 @@
 #include "test_common.h"
 
 #define A_MATRIX {{1,2,3},{5,6,7},{9,10,11}}
+#define MAT3_ARRAY {1, 5, 2, 7, 12, 1, 4, 6, 0}
 
 TEST_IMPL(GLM_PREFIX, mat3_copy) {
   mat3 m1 = A_MATRIX;
@@ -304,6 +305,23 @@ TEST_IMPL(GLM_PREFIX, mat3_rmc) {
   r2 = v[0] * v1[0] + v[1] * v1[1] + v[2] * v1[2];
 
   ASSERT(test_eq(r1, r2))
+
+  TEST_SUCCESS
+}
+
+
+TEST_IMPL(GLM_PREFIX, mat3_make) {
+  mat3 dest;
+  unsigned int i, j;
+  float src[9] = MAT3_ARRAY;
+
+  GLM(mat3_make)(src, dest);
+
+  for (i = 0, j = 0; i < sizeof(src) / sizeof(float); i+=3, j++) {
+    ASSERT(test_eq(dest[j][0], src[i]))
+    ASSERT(test_eq(dest[j][1], src[i+1]))
+    ASSERT(test_eq(dest[j][2], src[i+2]))
+  }
 
   TEST_SUCCESS
 }

--- a/test/tests.h
+++ b/test/tests.h
@@ -168,6 +168,7 @@ TEST_DECLARE(glm_mat3_inv)
 TEST_DECLARE(glm_mat3_swap_col)
 TEST_DECLARE(glm_mat3_swap_row)
 TEST_DECLARE(glm_mat3_rmc)
+TEST_DECLARE(glm_mat3_make)
 
 TEST_DECLARE(glmc_mat3_copy)
 TEST_DECLARE(glmc_mat3_identity)
@@ -185,6 +186,7 @@ TEST_DECLARE(glmc_mat3_inv)
 TEST_DECLARE(glmc_mat3_swap_col)
 TEST_DECLARE(glmc_mat3_swap_row)
 TEST_DECLARE(glmc_mat3_rmc)
+TEST_DECLARE(glmc_mat3_make)
 
 TEST_DECLARE(MACRO_GLM_MAT2_IDENTITY_INIT)
 TEST_DECLARE(MACRO_GLM_MAT2_ZERO_INIT)
@@ -1009,6 +1011,7 @@ TEST_LIST {
   TEST_ENTRY(glm_mat3_swap_col)
   TEST_ENTRY(glm_mat3_swap_row)
   TEST_ENTRY(glm_mat3_rmc)
+  TEST_ENTRY(glm_mat3_make)
 
   TEST_ENTRY(glmc_mat3_copy)
   TEST_ENTRY(glmc_mat3_identity)
@@ -1026,6 +1029,7 @@ TEST_LIST {
   TEST_ENTRY(glmc_mat3_swap_col)
   TEST_ENTRY(glmc_mat3_swap_row)
   TEST_ENTRY(glmc_mat3_rmc)
+  TEST_ENTRY(glmc_mat3_make)
   
   TEST_ENTRY(MACRO_GLM_MAT2_IDENTITY_INIT)
   TEST_ENTRY(MACRO_GLM_MAT2_ZERO_INIT)


### PR DESCRIPTION
Function takes in a 9 element float array
and converts it into a mat3 matrix.