### PR TITLE
io: fix test runner.c implicit declaration glm_arch_print

### DIFF
--- a/include/cglm/io.h
+++ b/include/cglm/io.h
@@ -392,6 +392,8 @@ glm_aabb_print(vec3                    bbox[2],
 #define glm_vec2_print(v, s) (void)v; (void)s;
 #define glm_versor_print(v, s) (void)v; (void)s;
 #define glm_aabb_print(v, t, s) (void)v; (void)t; (void)s;
+#define glm_arch_print(s) (void)s;
+#define glm_arch_print_name(s) (void)s;
 
 #endif
 #endif /* cglm_io_h */


### PR DESCRIPTION
Problem:
```
../test/runner.c:29:3: error: implicit declaration of function ‘glm_arch_print’ [-Werror=implicit-function-declaration]
   29 |   glm_arch_print(stderr);
      |   ^~~~~~~~~~~~~~
      |   glm_vec2_print
```

`glm_arch_print` is not available unless you add the `DEBUG` macro.