### PR TITLE
ci: update mymindstorm/setup-emsdk to v12

### DIFF
--- a/.github/workflows/cmake-wasm.yml
+++ b/.github/workflows/cmake-wasm.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup emsdk
-      uses: mymindstorm/setup-emsdk@v11
+      uses: mymindstorm/setup-emsdk@v12
 
     - name: Verify emsdk
       run: emcc -v


### PR DESCRIPTION
Github is using node16 by default for actions, so it might worth to update this to latest version supporting node16 by default.

The updated github action passed [here](https://github.com/myfreeer/cglm/actions/runs/5266731532).

See also:
* <https://github.com/mymindstorm/setup-emsdk/releases/tag/v12>
* <https://github.com/mymindstorm/setup-emsdk/issues/28>
* <https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/>
* <https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default>