### PR TITLE
quat: add new function glm_quat_make

### DIFF
--- a/docs/source/quat.rst
+++ b/docs/source/quat.rst
@@ -62,6 +62,7 @@ Functions:
 #. :c:func:`glm_quat_rotate`
 #. :c:func:`glm_quat_rotate_at`
 #. :c:func:`glm_quat_rotate_atm`
+#. :c:func:`glm_quat_make`
 
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -420,3 +421,13 @@ Functions documentation
       | *[in, out]*  **m**      existing transform matrix to rotate
       | *[in]*       **q**      quaternion
       | *[in]*       **pivot**  pivot
+
+.. c:function:: void glm_quat_make(float * __restrict src, versor dest)
+
+    Create quaternion from pointer
+
+    | NOTE: **@src** must contain 4 elements. cglm store quaternions as [x, y, z, w].
+
+    Parameters:
+      | *[in]*  **src**  pointer to an array of floats
+      | *[out]* **dest** destination quaternion

--- a/include/cglm/call/quat.h
+++ b/include/cglm/call/quat.h
@@ -161,6 +161,10 @@ CGLM_EXPORT
 void
 glmc_quat_rotate_atm(mat4 m, versor q, vec3 pivot);
 
+CGLM_EXPORT
+void
+glmc_quat_make(float * __restrict src, versor dest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/cglm/quat.h
+++ b/include/cglm/quat.h
@@ -49,6 +49,7 @@
                                   versor dest);
    CGLM_INLINE void glm_quat_rotatev(versor q, vec3 v, vec3 dest);
    CGLM_INLINE void glm_quat_rotate(mat4 m, versor q, mat4 dest);
+   CGLM_INLINE void glm_quat_make(float * restrict src, versor dest);
  */
 
 #ifndef cglm_quat_h
@@ -883,6 +884,19 @@ glm_quat_rotate_atm(mat4 m, versor q, vec3 pivot) {
   glm_translate_make(m, pivot);
   glm_quat_rotate(m, q, m);
   glm_translate(m, pivotInv);
+}
+
+/*!
+ * @brief Create quaternion from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @param[out] dest quaternion
+ */
+CGLM_INLINE
+void
+glm_quat_make(float * __restrict src, versor dest) {
+  dest[0] = src[0]; dest[1] = src[1];
+  dest[2] = src[2]; dest[3] = src[3];
 }
 
 #endif /* cglm_quat_h */

--- a/include/cglm/struct/quat.h
+++ b/include/cglm/struct/quat.h
@@ -44,6 +44,7 @@
    CGLM_INLINE mat4s   glms_quat_rotate(mat4s m, versors q)
    CGLM_INLINE mat4s   glms_quat_rotate_at(mat4s m, versors q, vec3s pivot)
    CGLM_INLINE mat4s   glms_quat_rotate_atm(versors q, vec3s pivot)
+   CGLM_INLINE void    glms_quat_make(float * restrict src)
  */
 
 #ifndef cglms_quat_h
@@ -562,6 +563,20 @@ mat4s
 glms_quat_(rotate_atm)(versors q, vec3s pivot) {
   mat4s dest;
   glm_quat_rotate_atm(dest.raw, q.raw, pivot.raw);
+  return dest;
+}
+
+/*!
+ * @brief Create CGLM quaternion from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @returns constructed quaternion from raw pointer
+ */
+CGLM_INLINE
+versors
+glms_quat_(make)(float * __restrict src) {
+  versors dest;
+  glm_quat_make(src, dest.raw);
   return dest;
 }
 

--- a/src/quat.c
+++ b/src/quat.c
@@ -229,3 +229,9 @@ void
 glmc_quat_rotate_atm(mat4 m, versor q, vec3 pivot) {
   glm_quat_rotate_atm(m, q, pivot);
 }
+
+CGLM_EXPORT
+void
+glmc_quat_make(float * __restrict src, versor dest) {
+  glm_quat_make(src, dest);
+}

--- a/test/src/test_quat.h
+++ b/test/src/test_quat.h
@@ -1084,3 +1084,15 @@ TEST_IMPL(GLM_PREFIX, quat_rotate_atm) {
 
   TEST_SUCCESS
 }
+
+TEST_IMPL(GLM_PREFIX, quat_make) {
+  versor dest;
+  float src[4] = {7.2f, 1.0f, 2.5f, 6.1f};
+
+  GLM(quat_make)(src, dest);
+  for (unsigned int i = 0; i < sizeof(src) / sizeof(float); i++) {
+    ASSERT(test_eq(src[i], dest[i]));
+  }
+
+  TEST_SUCCESS
+}

--- a/test/tests.h
+++ b/test/tests.h
@@ -311,6 +311,7 @@ TEST_DECLARE(glm_quat_rotate)
 TEST_DECLARE(glm_quat_rotate_at)
 TEST_DECLARE(glm_quat_rotate_atm)
 TEST_DECLARE(glm_quat_from_vecs)
+TEST_DECLARE(glm_quat_make)
 
 TEST_DECLARE(glmc_quat_identity)
 TEST_DECLARE(glmc_quat_identity_array)
@@ -349,6 +350,7 @@ TEST_DECLARE(glmc_quat_rotate)
 TEST_DECLARE(glmc_quat_rotate_at)
 TEST_DECLARE(glmc_quat_rotate_atm)
 TEST_DECLARE(glmc_quat_from_vecs)
+TEST_DECLARE(glmc_quat_make)
 
 /* bezier */
 TEST_DECLARE(bezier)
@@ -1158,6 +1160,7 @@ TEST_LIST {
   TEST_ENTRY(glm_quat_rotate_at)
   TEST_ENTRY(glm_quat_rotate_atm)
   TEST_ENTRY(glm_quat_from_vecs)
+  TEST_ENTRY(glm_quat_make)
 
   TEST_ENTRY(glmc_quat_identity)
   TEST_ENTRY(glmc_quat_identity_array)
@@ -1196,6 +1199,7 @@ TEST_LIST {
   TEST_ENTRY(glmc_quat_rotate_at)
   TEST_ENTRY(glmc_quat_rotate_atm)
   TEST_ENTRY(glmc_quat_from_vecs)
+  TEST_ENTRY(glmc_quat_make)
 
   /* bezier */
   TEST_ENTRY(bezier)


### PR DESCRIPTION
Not really necessary. Could just define the versor your self, but to be compatible with

https://glm.g-truc.net/0.9.9/api/a00722.html

and other portions of the API. Add new function that takes in a 4 element float array
and converts it into a quaternion.
