### PR TITLE
test_quat: add more robust quat_make test

### DIFF
--- a/docs/source/quat.rst
+++ b/docs/source/quat.rst
@@ -426,7 +426,7 @@ Functions documentation
 
     Create quaternion from pointer
 
-    | NOTE: **@src** must contain 4 elements. cglm store quaternions as [x, y, z, w].
+    | NOTE: **@src** must contain at least 4 elements. cglm store quaternions as [x, y, z, w].
 
     Parameters:
       | *[in]*  **src**  pointer to an array of floats

--- a/include/cglm/struct/quat.h
+++ b/include/cglm/struct/quat.h
@@ -44,7 +44,7 @@
    CGLM_INLINE mat4s   glms_quat_rotate(mat4s m, versors q)
    CGLM_INLINE mat4s   glms_quat_rotate_at(mat4s m, versors q, vec3s pivot)
    CGLM_INLINE mat4s   glms_quat_rotate_atm(versors q, vec3s pivot)
-   CGLM_INLINE void    glms_quat_make(float * restrict src)
+   CGLM_INLINE versors glms_quat_make(float * restrict src)
  */
 
 #ifndef cglms_quat_h

--- a/test/src/test_quat.h
+++ b/test/src/test_quat.h
@@ -1086,12 +1086,22 @@ TEST_IMPL(GLM_PREFIX, quat_rotate_atm) {
 }
 
 TEST_IMPL(GLM_PREFIX, quat_make) {
-  versor dest;
-  float src[4] = {7.2f, 1.0f, 2.5f, 6.1f};
+  versor dest[3];
+  float src[12] = {
+    7.2f, 1.0f, 2.5f, 6.1f,
+    0.2f, 2.8f, 17.3f, 5.1f,
+    4.2f, 7.3f, 6.6f, 8.8f
+  };
 
-  GLM(quat_make)(src, dest);
-  for (unsigned int i = 0; i < sizeof(src) / sizeof(float); i++) {
-    ASSERT(test_eq(src[i], dest[i]));
+  float *srcp = src;
+  unsigned int i, j;
+
+  for (i = 0, j = 0; i < sizeof(src) / sizeof(float); i+=4,j++) {
+    GLM(quat_make)(srcp + i, dest[j]);
+    ASSERT(test_eq(src[ i ], dest[j][0]));
+    ASSERT(test_eq(src[i+1], dest[j][1]));
+    ASSERT(test_eq(src[i+2], dest[j][2]));
+    ASSERT(test_eq(src[i+3], dest[j][3]));
   }
 
   TEST_SUCCESS


### PR DESCRIPTION
Makes it so that it's easier to identify
the potential use case of function. Commit also
includes a fix to the struct/quat.h glms_quat_make comment.
Should be returning versors it's not
a void function.