### PR TITLE
vec2: add new function glm_vec2_make

### DIFF
--- a/docs/source/vec2.rst
+++ b/docs/source/vec2.rst
@@ -51,6 +51,7 @@ Functions:
 #. :c:func:`glm_vec2_minv`
 #. :c:func:`glm_vec2_clamp`
 #. :c:func:`glm_vec2_lerp`
+#. :c:func:`glm_vec2_make`
 
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -373,3 +374,12 @@ Functions documentation
       | *[in]*  **to**     to value
       | *[in]*  **t**      interpolant (amount) clamped between 0 and 1
       | *[out]* **dest**   destination
+
+.. c:function:: void glm_vec2_make(float * __restrict src, vec2 dest)
+
+    Create two dimensional vector from pointer
+
+    | NOTE: **@src** must contain at least 2 elements.
+    Parameters:
+      | *[in]*  **src**  pointer to an array of floats
+      | *[out]* **dest** destination vector

--- a/include/cglm/call/vec2.h
+++ b/include/cglm/call/vec2.h
@@ -165,6 +165,10 @@ CGLM_EXPORT
 void
 glmc_vec2_complex_conjugate(vec2 a, vec2 dest);
 
+CGLM_EXPORT
+void
+glmc_vec2_make(float * __restrict src, vec2 dest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/cglm/struct/vec2.h
+++ b/include/cglm/struct/vec2.h
@@ -46,6 +46,7 @@
    CGLM_INLINE vec2s glms_vec2_minv(vec2s a, vec2s b)
    CGLM_INLINE vec2s glms_vec2_clamp(vec2s v, float minVal, float maxVal)
    CGLM_INLINE vec2s glms_vec2_lerp(vec2s from, vec2s to, float t)
+   CGLM_INLINE vec2s glms_vec2_make(float * restrict src)
  */
 
 #ifndef cglms_vec2s_h
@@ -556,6 +557,20 @@ glms_vec2_(lerp)(vec2s from, vec2s to, float t) {
   vec2s r;
   glm_vec2_lerp(from.raw, to.raw, t, r.raw);
   return r;
+}
+
+/*!
+ * @brief Create two dimensional vector from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @returns constructed 2D vector from raw pointer
+ */
+CGLM_INLINE
+vec2s
+glms_vec2_(make)(float * __restrict src) {
+  vec2s dest;
+  glm_vec2_make(src, dest.raw);
+  return dest;
 }
 
 #endif /* cglms_vec2s_h */

--- a/include/cglm/vec2.h
+++ b/include/cglm/vec2.h
@@ -47,6 +47,7 @@
    CGLM_INLINE void  glm_vec2_minv(vec2 v1, vec2 v2, vec2 dest)
    CGLM_INLINE void  glm_vec2_clamp(vec2 v, float minVal, float maxVal)
    CGLM_INLINE void  glm_vec2_lerp(vec2 from, vec2 to, float t, vec2 dest)
+   CGLM_INLINE void  glm_vec2_make(float * restrict src, vec2 dest)
 
  */
 
@@ -580,6 +581,18 @@ glm_vec2_lerp(vec2 from, vec2 to, float t, vec2 dest) {
   glm_vec2_sub(to, from, v);
   glm_vec2_mul(s, v, v);
   glm_vec2_add(from, v, dest);
+}
+
+/*!
+ * @brief Create two dimensional vector from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @param[out] dest destination vector
+ */
+CGLM_INLINE
+void
+glm_vec2_make(float * __restrict src, vec2 dest) {
+  dest[0] = src[0]; dest[1] = src[1];
 }
 
 #endif /* cglm_vec2_h */

--- a/src/vec2.c
+++ b/src/vec2.c
@@ -235,3 +235,9 @@ void
 glmc_vec2_complex_conjugate(vec2 a, vec2 dest) {
   glm_vec2_complex_conjugate(a, dest);
 }
+
+CGLM_EXPORT
+void
+glmc_vec2_make(float * __restrict src, vec2 dest) {
+  glm_vec2_make(src, dest);
+}

--- a/test/src/test_vec2.h
+++ b/test/src/test_vec2.h
@@ -637,3 +637,23 @@ TEST_IMPL(GLM_PREFIX, vec2_complex_div) {
 
   TEST_SUCCESS
 }
+
+TEST_IMPL(GLM_PREFIX, vec2_make) {
+  float src[6] = {
+    7.2f, 1.0f,
+    2.5f, 6.1f,
+    17.7f, 4.3f
+  };
+  vec2 dest[3];
+
+  float *srcp = src;
+  unsigned int i, j;
+
+  for (i = 0, j = 0; i < sizeof(src) / sizeof(float); i+=2,j++) {
+    GLM(vec2_make)(srcp + i, dest[j]);
+    ASSERT(test_eq(src[ i ], dest[j][0]));
+    ASSERT(test_eq(src[i+1], dest[j][1]));
+  }
+
+  TEST_SUCCESS
+}

--- a/test/tests.h
+++ b/test/tests.h
@@ -398,6 +398,7 @@ TEST_DECLARE(glm_vec2_abs)
 TEST_DECLARE(glm_vec2_lerp)
 TEST_DECLARE(glm_vec2_complex_mul)
 TEST_DECLARE(glm_vec2_complex_div)
+TEST_DECLARE(glm_vec2_make)
 
 TEST_DECLARE(glmc_vec2)
 TEST_DECLARE(glmc_vec2_copy)
@@ -436,6 +437,7 @@ TEST_DECLARE(glmc_vec2_abs)
 TEST_DECLARE(glmc_vec2_lerp)
 TEST_DECLARE(glmc_vec2_complex_mul)
 TEST_DECLARE(glmc_vec2_complex_div)
+TEST_DECLARE(glmc_vec2_make)
 
 /* vec3 */
 TEST_DECLARE(MACRO_GLM_VEC3_ONE_INIT)
@@ -1246,6 +1248,7 @@ TEST_LIST {
   TEST_ENTRY(glm_vec2_lerp)
   TEST_ENTRY(glm_vec2_complex_mul)
   TEST_ENTRY(glm_vec2_complex_div)
+  TEST_ENTRY(glm_vec2_make)
 
   TEST_ENTRY(glmc_vec2)
   TEST_ENTRY(glmc_vec2_copy)
@@ -1284,6 +1287,7 @@ TEST_LIST {
   TEST_ENTRY(glmc_vec2_lerp)
   TEST_ENTRY(glmc_vec2_complex_mul)
   TEST_ENTRY(glmc_vec2_complex_div)
+  TEST_ENTRY(glmc_vec2_make)
 
   /* vec3 */
   TEST_ENTRY(MACRO_GLM_VEC3_ONE_INIT)


### PR DESCRIPTION
Just a copy of glm_vec2, but with the
word `_make` suffixed at the end.

Function takes in a float array array must be
at least of size 2 and converts it into
a 2D vector.

Hey, @recp finishing off last `_make` calls to close off https://github.com/recp/cglm/issues/284.

Realized for vec2 there's no point in extra function `glm_vec2_make` as it's already defined as
`glm_vec2`. Creating PR for discussion. Also do we want to create new headers for the
other matrices?
* [mat2x3](https://glm.g-truc.net/0.9.4/api/a00158.html#ga87d29f47fbd3990a344be2eac404aee3)
* [mat2x4](https://glm.g-truc.net/0.9.4/api/a00158.html#gaab3df4b27b38505f1413f507ebc43d18)
* [mat3x2](https://glm.g-truc.net/0.9.4/api/a00158.html#ga8764d696bd4dfb91d689ca196414b36b)
* [mat3x4](https://glm.g-truc.net/0.9.4/api/a00158.html#gaae2b48f5109461f13f63ccf5b4cde672)
* [mat4x2](https://glm.g-truc.net/0.9.4/api/a00158.html#ga3717ecbb38c8a24043ee17bdff94bca5)
* [mat4x3](https://glm.g-truc.net/0.9.4/api/a00158.html#gae91cc925c4154c5fe4ef1fc7da96a9a8)