### PR TITLE
vec3: add new function glm_vec3_make

### DIFF
--- a/docs/source/vec3.rst
+++ b/docs/source/vec3.rst
@@ -79,6 +79,7 @@ Functions:
 #. :c:func:`glm_vec3_ortho`
 #. :c:func:`glm_vec3_clamp`
 #. :c:func:`glm_vec3_lerp`
+#. :c:func:`glm_vec3_make`
 
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -501,3 +502,13 @@ Functions documentation
       | *[in]*  **to**     to value
       | *[in]*  **t**      interpolant (amount) clamped between 0 and 1
       | *[out]* **dest**   destination
+
+.. c:function:: void glm_vec3_make(float * __restrict src, vec3 dest)
+
+    Create three dimensional vector from pointer
+
+    | NOTE: **@src** must contain at least 3 elements.
+
+    Parameters:
+      | *[in]*  **src**  pointer to an array of floats
+      | *[out]* **dest** destination vector

--- a/include/cglm/call/vec3.h
+++ b/include/cglm/call/vec3.h
@@ -306,6 +306,10 @@ CGLM_EXPORT
 void
 glmc_vec3_sqrt(vec3 v, vec3 dest);
 
+CGLM_EXPORT
+void
+glmc_vec3_make(float * __restrict src, vec3 dest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/cglm/struct/vec3.h
+++ b/include/cglm/struct/vec3.h
@@ -70,6 +70,7 @@
    CGLM_INLINE vec3s glms_vec3_smoothinterp(vec3s from, vec3s to, float t);
    CGLM_INLINE vec3s glms_vec3_smoothinterpc(vec3s from, vec3s to, float t);
    CGLM_INLINE vec3s glms_vec3_swizzle(vec3s v, int mask);
+   CGLM_INLINE vec3s glms_vec3_make(float * restrict src);
 
  Convenient:
    CGLM_INLINE vec3s glms_cross(vec3s a, vec3s b);
@@ -964,6 +965,20 @@ vec3s
 glms_vec3_(swizzle)(vec3s v, int mask) {
   vec3s dest;
   glm_vec3_swizzle(v.raw, mask, dest.raw);
+  return dest;
+}
+
+/*!
+ * @brief Create three dimensional vector from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @returns constructed 3D vector from raw pointer
+ */
+CGLM_INLINE
+vec3s
+glms_vec3_(make)(float * __restrict src) {
+  vec3s dest;
+  glm_vec3_make(src, dest.raw);
   return dest;
 }
 

--- a/include/cglm/vec3.h
+++ b/include/cglm/vec3.h
@@ -73,6 +73,7 @@
    CGLM_INLINE void  glm_vec3_smoothinterp(vec3 from, vec3 to, float t, vec3 dest);
    CGLM_INLINE void  glm_vec3_smoothinterpc(vec3 from, vec3 to, float t, vec3 dest);
    CGLM_INLINE void  glm_vec3_swizzle(vec3 v, int mask, vec3 dest);
+   CGLM_INLINE void  glm_vec3_make(float * restrict src, vec3 dest);
 
  Convenient:
    CGLM_INLINE void  glm_cross(vec3 a, vec3 b, vec3 d);
@@ -1077,6 +1078,20 @@ CGLM_INLINE
 void
 glm_normalize_to(vec3 v, vec3 dest) {
   glm_vec3_normalize_to(v, dest);
+}
+
+/*!
+ * @brief Create three dimensional vector from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @param[out] dest destination vector
+ */
+CGLM_INLINE
+void
+glm_vec3_make(float * __restrict src, vec3 dest) {
+  dest[0] = src[0];
+  dest[1] = src[1];
+  dest[2] = src[2];
 }
 
 #endif /* cglm_vec3_h */

--- a/src/vec3.c
+++ b/src/vec3.c
@@ -417,3 +417,9 @@ void
 glmc_vec3_sqrt(vec3 v, vec3 dest) {
   glm_vec3_sqrt(v, dest);
 }
+
+CGLM_EXPORT
+void
+glmc_vec3_make(float * __restrict src, vec3 dest) {
+  glm_vec3_make(src, dest);
+}

--- a/test/src/test_vec3.h
+++ b/test/src/test_vec3.h
@@ -1729,3 +1729,24 @@ TEST_IMPL(GLM_PREFIX, vec3_sqrt) {
 
   TEST_SUCCESS
 }
+
+TEST_IMPL(GLM_PREFIX, vec3_make) {
+  float src[9] = {
+    7.2f, 1.0f, 5.8f,
+    2.5f, 6.1f, 9.9f,
+    17.7f, 4.3f, 3.2f
+  };
+  vec3 dest[3];
+
+  float *srcp = src;
+  unsigned int i, j;
+
+  for (i = 0, j = 0; i < sizeof(src) / sizeof(float); i+=3,j++) {
+    GLM(vec3_make)(srcp + i, dest[j]);
+    ASSERT(test_eq(src[ i ], dest[j][0]));
+    ASSERT(test_eq(src[i+1], dest[j][1]));
+    ASSERT(test_eq(src[i+2], dest[j][2]));
+  }
+
+  TEST_SUCCESS
+}

--- a/test/tests.h
+++ b/test/tests.h
@@ -531,6 +531,7 @@ TEST_DECLARE(glm_vec3_abs)
 TEST_DECLARE(glm_vec3_fract)
 TEST_DECLARE(glm_vec3_hadd)
 TEST_DECLARE(glm_vec3_sqrt)
+TEST_DECLARE(glm_vec3_make)
 
 TEST_DECLARE(glmc_vec3)
 TEST_DECLARE(glmc_vec3_copy)
@@ -600,6 +601,7 @@ TEST_DECLARE(glmc_vec3_abs)
 TEST_DECLARE(glmc_vec3_fract)
 TEST_DECLARE(glmc_vec3_hadd)
 TEST_DECLARE(glmc_vec3_sqrt)
+TEST_DECLARE(glmc_vec3_make)
 
 /* vec4 */
 TEST_DECLARE(MACRO_GLM_VEC4_ONE_INIT)
@@ -1378,6 +1380,7 @@ TEST_LIST {
   TEST_ENTRY(glm_vec3_fract)
   TEST_ENTRY(glm_vec3_hadd)
   TEST_ENTRY(glm_vec3_sqrt)
+  TEST_ENTRY(glm_vec3_make)
 
   TEST_ENTRY(glmc_vec3)
   TEST_ENTRY(glmc_vec3_copy)
@@ -1447,6 +1450,7 @@ TEST_LIST {
   TEST_ENTRY(glmc_vec3_fract)
   TEST_ENTRY(glmc_vec3_hadd)
   TEST_ENTRY(glmc_vec3_sqrt)
+  TEST_ENTRY(glmc_vec3_make)
 
   /* vec4 */
   TEST_ENTRY(MACRO_GLM_VEC4_ONE_INIT)


### PR DESCRIPTION
Function takes in a float array. Array must be
at least of size 3 and converts it into
a 3D vector.