### PR TITLE
vec4: add new function glm_vec4_make

### DIFF
--- a/docs/source/vec4.rst
+++ b/docs/source/vec4.rst
@@ -59,6 +59,7 @@ Functions:
 #. :c:func:`glm_vec4_clamp`
 #. :c:func:`glm_vec4_lerp`
 #. :c:func:`glm_vec4_cubic`
+#. :c:func:`glm_vec4_make`
 
 Functions documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -406,3 +407,12 @@ Functions documentation
     Parameters:
       | *[in]*  **s**      parameter
       | *[out]* **dest**   destination
+
+.. c:function:: void glm_vec4_make(float * __restrict src, vec4 dest)
+
+    Create four dimensional vector from pointer
+
+    | NOTE: **@src** must contain at least 4 elements.
+    Parameters:
+      | *[in]*  **src**  pointer to an array of floats
+      | *[out]* **dest** destination vector

--- a/include/cglm/call/vec4.h
+++ b/include/cglm/call/vec4.h
@@ -283,6 +283,10 @@ CGLM_EXPORT
 void
 glmc_vec4_sqrt(vec4 v, vec4 dest);
 
+CGLM_EXPORT
+void
+glmc_vec4_make(float * __restrict src, vec4 dest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/cglm/struct/vec4.h
+++ b/include/cglm/struct/vec4.h
@@ -61,6 +61,7 @@
    CGLM_INLINE vec4s glms_vec4_smoothinterpc(vec4s from, vec4s to, float t);
    CGLM_INLINE vec4s glms_vec4_cubic(float s);
    CGLM_INLINE vec4s glms_vec4_swizzle(vec4s v, int mask);
+   CGLM_INLINE vec4s glms_vec4_make(float * restrict src);
  */
 
 #ifndef cglms_vec4s_h
@@ -808,6 +809,20 @@ vec4s
 glms_vec4_(swizzle)(vec4s v, int mask) {
   vec4s dest;
   glm_vec4_swizzle(v.raw, mask, dest.raw);
+  return dest;
+}
+
+/*!
+ * @brief Create four dimensional vector from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @returns constructed 4D vector from raw pointer
+ */
+CGLM_INLINE
+vec4s
+glms_vec4_(make)(float * __restrict src) {
+  vec4s dest;
+  glm_vec4_make(src, dest.raw);
   return dest;
 }
 

--- a/include/cglm/vec4.h
+++ b/include/cglm/vec4.h
@@ -58,6 +58,7 @@
    CGLM_INLINE void  glm_vec4_smoothinterp(vec4 from, vec4 to, float t, vec4 dest);
    CGLM_INLINE void  glm_vec4_smoothinterpc(vec4 from, vec4 to, float t, vec4 dest);
    CGLM_INLINE void  glm_vec4_swizzle(vec4 v, int mask, vec4 dest);
+   CGLM_INLINE void  glm_vec4_make(float * restrict src, vec4 dest);
 
  DEPRECATED:
    glm_vec4_dup
@@ -1131,6 +1132,19 @@ glm_vec4_swizzle(vec4 v, int mask, vec4 dest) {
   t[3] = v[(mask & (3 << 6)) >> 6];
 
   glm_vec4_copy(t, dest);
+}
+
+/*!
+ * @brief Create four dimensional vector from pointer
+ *
+ * @param[in]  src  pointer to an array of floats
+ * @param[out] dest destination vector
+ */
+CGLM_INLINE
+void
+glm_vec4_make(float * __restrict src, vec4 dest) {
+  dest[0] = src[0]; dest[1] = src[1];
+  dest[2] = src[2]; dest[3] = src[3];
 }
 
 #endif /* cglm_vec4_h */

--- a/src/vec4.c
+++ b/src/vec4.c
@@ -381,3 +381,9 @@ void
 glmc_vec4_sqrt(vec4 v, vec4 dest) {
   glm_vec4_sqrt(v, dest);
 }
+
+CGLM_EXPORT
+void
+glmc_vec4_make(float * __restrict src, vec4 dest) {
+  glm_vec4_make(src, dest);
+}

--- a/test/src/test_vec4.h
+++ b/test/src/test_vec4.h
@@ -1418,3 +1418,25 @@ TEST_IMPL(GLM_PREFIX, vec4_sqrt) {
 
   TEST_SUCCESS
 }
+
+TEST_IMPL(GLM_PREFIX, vec4_make) {
+  float src[12] = {
+    7.2f, 1.0f, 5.8f, 0.0f,
+    2.5f, 6.1f, 9.9f, 1.0f,
+    17.7f, 4.3f, 3.2f, 1.0f
+  };
+  vec4 dest[3];
+
+  float *srcp = src;
+  unsigned int i, j;
+
+  for (i = 0, j = 0; i < sizeof(src) / sizeof(float); i+=4,j++) {
+    GLM(vec4_make)(srcp + i, dest[j]);
+    ASSERT(test_eq(src[ i ], dest[j][0]));
+    ASSERT(test_eq(src[i+1], dest[j][1]));
+    ASSERT(test_eq(src[i+2], dest[j][2]));
+    ASSERT(test_eq(src[i+3], dest[j][3]));
+  }
+
+  TEST_SUCCESS
+}

--- a/test/tests.h
+++ b/test/tests.h
@@ -681,6 +681,7 @@ TEST_DECLARE(glm_vec4_abs)
 TEST_DECLARE(glm_vec4_fract)
 TEST_DECLARE(glm_vec4_hadd)
 TEST_DECLARE(glm_vec4_sqrt)
+TEST_DECLARE(glm_vec4_make)
 
 TEST_DECLARE(glmc_vec4)
 TEST_DECLARE(glmc_vec4_copy3)
@@ -746,6 +747,7 @@ TEST_DECLARE(glmc_vec4_abs)
 TEST_DECLARE(glmc_vec4_fract)
 TEST_DECLARE(glmc_vec4_hadd)
 TEST_DECLARE(glmc_vec4_sqrt)
+TEST_DECLARE(glmc_vec4_make)
 
 /* ivec2 */
 TEST_DECLARE(glm_ivec2)
@@ -1528,6 +1530,7 @@ TEST_LIST {
   TEST_ENTRY(glm_vec4_fract)
   TEST_ENTRY(glm_vec4_hadd)
   TEST_ENTRY(glm_vec4_sqrt)
+  TEST_ENTRY(glm_vec4_make)
 
   TEST_ENTRY(glmc_vec4)
   TEST_ENTRY(glmc_vec4_copy3)
@@ -1593,6 +1596,7 @@ TEST_LIST {
   TEST_ENTRY(glmc_vec4_fract)
   TEST_ENTRY(glmc_vec4_hadd)
   TEST_ENTRY(glmc_vec4_sqrt)
+  TEST_ENTRY(glmc_vec4_make)
 
   /* ivec2 */
   TEST_ENTRY(glm_ivec2)


### PR DESCRIPTION
Function takes in a float array. Array must be
at least of size 4 and converts it into
a 4D vector.