### PR TITLE
drop "-Werror" to allow skip warnings on production build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(MSVC)
     string(REGEX REPLACE "/RTC(su|[1su])" "" ${flag_var} "${${flag_var}}")
   endforeach(flag_var)
 else()
-  add_compile_options(-Wall -Werror -O3)
+  add_compile_options(-Wall -O3)
 endif()
 
 get_directory_property(hasParent PARENT_DIRECTORY)

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,8 +11,7 @@ AM_CFLAGS = -Wall \
             -std=gnu11 \
             -O3 \
             -Wstrict-aliasing=2 \
-            -fstrict-aliasing \
-            -Werror=strict-prototypes
+            -fstrict-aliasing
 
 lib_LTLIBRARIES = libcglm.la
 libcglm_la_LDFLAGS = -no-undefined -version-info 0:1:0

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([cglm], [0.9.1], [info@recp.me])
-AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects serial-tests])
+AM_INIT_AUTOMAKE([-Wall foreign subdir-objects serial-tests])
 
 # Don't use the default cflags (-O2 -g), we set ours manually in Makefile.am.
 : ${CFLAGS=""}

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,6 @@ project('cglm', 'c',
     license : 'mit',
     default_options : [
         'c_std=c11',
-        'werror=true',
         'warning_level=2',
         'buildtype=release'
     ]


### PR DESCRIPTION
While the `-Werror` flag is useful during development as it forces the handling of all warnings, it can create issues when building the code in different environments, where certain innocuous warnings might be treated as errors and prevent a successful build. 

This pull request removes the `-Werror` flag from the project build files.
