### PR TITLE
more robust __builtin_assume_aligned detection

### DIFF
--- a/include/cglm/types.h
+++ b/include/cglm/types.h
@@ -32,13 +32,27 @@
 #  define CGLM_ALIGN_MAT CGLM_ALIGN(16)
 #endif
 
-#if defined(__has_builtin)
-#  if __has_builtin(__builtin_assume_aligned)
-#    define CGLM_ASSUME_ALIGNED(expr, alignment) \
-    __builtin_assume_aligned((expr), (alignment))
-#  else
-#    define CGLM_ASSUME_ALIGNED(expr, alignment) (expr)
+#ifndef CGLM_HAVE_BUILTIN_ASSUME_ALIGNED
+
+#  if defined(__has_builtin)
+#    if __has_builtin(__builtin_assume_aligned)
+#      define CGLM_HAVE_BUILTIN_ASSUME_ALIGNED 1
+#    endif
+#  elif defined(__GNUC__) && defined(__GNUC_MINOR__)
+#    if __GNUC__ >= 4 && __GNUC_MINOR__ >= 7
+#      define CGLM_HAVE_BUILTIN_ASSUME_ALIGNED 1
+#    endif
 #  endif
+
+#  ifndef CGLM_HAVE_BUILTIN_ASSUME_ALIGNED
+#    define CGLM_HAVE_BUILTIN_ASSUME_ALIGNED 0
+#  endif
+
+#endif
+
+#if CGLM_HAVE_BUILTIN_ASSUME_ALIGNED
+#  define CGLM_ASSUME_ALIGNED(expr, alignment) \
+     __builtin_assume_aligned((expr), (alignment))
 #else
 #  define CGLM_ASSUME_ALIGNED(expr, alignment) (expr)
 #endif

--- a/meson.build
+++ b/meson.build
@@ -17,11 +17,19 @@ cglm_args = []
 build_args = []
 
 if get_option('default_library') == 'static'
-    cglm_args = '-DCGLM_STATIC'
+    cglm_args += '-DCGLM_STATIC'
+endif
+
+if cc.compiles(
+    'int *test(char *p) { return (int*)__builtin_assume_aligned(p, 4); }',
+    name : '__builtin_assume_aligned test')
+    cglm_args += '-DCGLM_HAVE_BUILTIN_ASSUME_ALIGNED=1'
+else
+    cglm_args += '-DCGLM_HAVE_BUILTIN_ASSUME_ALIGNED=0'
 endif
 
 if host_machine.system() == 'windows'
-    build_args = '-DCGLM_EXPORTS'
+    build_args += '-DCGLM_EXPORTS'
 endif
 
 cglm_inc = include_directories('include')


### PR DESCRIPTION
`__builtin_assume_aligned` is available since GCC 4.7, but `__has_builtin` was added much later. Check for the GCC version if `__has_builtin` is not available.

Users can also define `CGLM_HAVE_BUILTIN_ASSUME_ALIGNED` to either 1 or 0 to explicitly enable/disable the use of `__builtin_assume_aligned`. Meson will do it automatically (by performing a configure-time test).