### PR TITLE
meson: don't build by default if used in a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,7 @@ cglm_dep = declare_dependency(
     dependencies : cglm_deps,
     compile_args : cglm_args,
     include_directories : cglm_inc,
+    build_by_default: not meson.is_subproject(),
     version : meson.project_version()
 )
 


### PR DESCRIPTION
This allows to do the following in a project using cglm as a subproject and avoid building cglm's standalone library if you only use inline versions of functions:

```meson
cglm_dep = dependency(
  'cglm',
  default_options: [ 'install=false' ]
).partial_dependency(
  compile_args: true,
  includes: true,
)

# Needed since it's won't be pulled in automatically now
libm_dep = meson.get_compiler('c').find_library('m', required: false)
```