### PR TITLE
Fix struct clipspace headers

### DIFF
--- a/include/cglm/struct/clipspace/ortho_lh_no.h
+++ b/include/cglm/struct/clipspace/ortho_lh_no.h
@@ -24,6 +24,8 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../vec3.h"
+#include "../../clipspace/ortho_lh_no.h"
 
 /*!
  * @brief set up orthographic projection matrix

--- a/include/cglm/struct/clipspace/ortho_lh_zo.h
+++ b/include/cglm/struct/clipspace/ortho_lh_zo.h
@@ -24,6 +24,8 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../vec3.h"
+#include "../../clipspace/ortho_lh_zo.h"
 
 /*!
  * @brief set up orthographic projection matrix

--- a/include/cglm/struct/clipspace/ortho_rh_no.h
+++ b/include/cglm/struct/clipspace/ortho_rh_no.h
@@ -24,6 +24,8 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../vec3.h"
+#include "../../clipspace/ortho_rh_no.h"
 
 /*!
  * @brief set up orthographic projection matrix

--- a/include/cglm/struct/clipspace/ortho_rh_zo.h
+++ b/include/cglm/struct/clipspace/ortho_rh_zo.h
@@ -24,6 +24,8 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../vec3.h"
+#include "../../clipspace/ortho_rh_zo.h"
 
 /*!
  * @brief set up orthographic projection matrix

--- a/include/cglm/struct/clipspace/persp_lh_no.h
+++ b/include/cglm/struct/clipspace/persp_lh_no.h
@@ -39,6 +39,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/persp_lh_no.h"
 
 /*!
  * @brief set up perspective peprojection matrix

--- a/include/cglm/struct/clipspace/persp_lh_zo.h
+++ b/include/cglm/struct/clipspace/persp_lh_zo.h
@@ -39,6 +39,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/persp_lh_zo.h"
 
 /*!
  * @brief set up perspective peprojection matrix

--- a/include/cglm/struct/clipspace/persp_rh_no.h
+++ b/include/cglm/struct/clipspace/persp_rh_no.h
@@ -39,6 +39,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/persp_rh_no.h"
 
 /*!
  * @brief set up perspective peprojection matrix

--- a/include/cglm/struct/clipspace/persp_rh_zo.h
+++ b/include/cglm/struct/clipspace/persp_rh_zo.h
@@ -39,6 +39,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/persp_rh_zo.h"
 
 /*!
  * @brief set up perspective peprojection matrix

--- a/include/cglm/struct/clipspace/project_no.h
+++ b/include/cglm/struct/clipspace/project_no.h
@@ -7,8 +7,9 @@
 
 /*
  Functions:
-   CGLM_INLINE vec3s glms_unprojecti_no(vec3s pos, mat4s invMat, vec4s vp, vec3 dest)
-   CGLM_INLINE vec3s glms_project_no(vec3s pos, mat4s m, vec4s vp, vec3s dest)
+   CGLM_INLINE vec3s glms_unprojecti_no(vec3s pos, mat4s invMat, vec4s vp)
+   CGLM_INLINE vec3s glms_project_no(vec3s pos, mat4s m, vec4s vp)
+   CGLM_INLINE float glms_project_z_no(vec3s v, mat4s m)
  */
 
 #ifndef cglms_project_no_h
@@ -18,6 +19,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/project_no.h"
 
 /*!
  * @brief maps the specified viewport coordinates into specified space [1]
@@ -48,7 +50,7 @@
  */
 CGLM_INLINE
 vec3s
-glms_unprojecti_no(vec3s pos, mat4s invMat, vec4s vp, vec3 dest) {
+glms_unprojecti_no(vec3s pos, mat4s invMat, vec4s vp) {
   vec3s dest;
   glm_unprojecti_no(pos.raw, invMat.raw, vp.raw, dest.raw);
   return dest;
@@ -69,7 +71,7 @@ glms_unprojecti_no(vec3s pos, mat4s invMat, vec4s vp, vec3 dest) {
  */
 CGLM_INLINE
 vec3s
-glms_project_no(vec3s pos, mat4s m, vec4s vp, vec3s dest) {
+glms_project_no(vec3s pos, mat4s m, vec4s vp) {
   vec3s dest;
   glm_project_no(pos.raw, m.raw, vp.raw, dest.raw);
   return dest;
@@ -88,7 +90,7 @@ glms_project_no(vec3s pos, mat4s m, vec4s vp, vec3s dest) {
  * @returns projected z coordinate
  */
 CGLM_INLINE
-vec3s
+float
 glms_project_z_no(vec3s v, mat4s m) {
   return glm_project_z_no(v.raw, m.raw);
 }

--- a/include/cglm/struct/clipspace/project_zo.h
+++ b/include/cglm/struct/clipspace/project_zo.h
@@ -7,8 +7,9 @@
 
 /*
  Functions:
-   CGLM_INLINE vec3s glms_unprojecti_no(vec3s pos, mat4s invMat, vec4s vp, vec3 dest)
-   CGLM_INLINE vec3s glms_project_no(vec3s pos, mat4s m, vec4s vp, vec3s dest)
+   CGLM_INLINE vec3s glms_unprojecti_no(vec3s pos, mat4s invMat, vec4s vp)
+   CGLM_INLINE vec3s glms_project_no(vec3s pos, mat4s m, vec4s vp)
+   CGLM_INLINE float glms_project_z_zo(vec3s v, mat4s m)
  */
 
 #ifndef cglms_project_zo_h
@@ -18,6 +19,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/project_zo.h"
 
 /*!
  * @brief maps the specified viewport coordinates into specified space [1]
@@ -48,7 +50,7 @@
  */
 CGLM_INLINE
 vec3s
-glms_unprojecti_zo(vec3s pos, mat4s invMat, vec4s vp, vec3 dest) {
+glms_unprojecti_zo(vec3s pos, mat4s invMat, vec4s vp) {
   vec3s dest;
   glm_unprojecti_zo(pos.raw, invMat.raw, vp.raw, dest.raw);
   return dest;
@@ -69,7 +71,7 @@ glms_unprojecti_zo(vec3s pos, mat4s invMat, vec4s vp, vec3 dest) {
  */
 CGLM_INLINE
 vec3s
-glms_project_zo(vec3s pos, mat4s m, vec4s vp, vec3 dest) {
+glms_project_zo(vec3s pos, mat4s m, vec4s vp) {
   vec3s dest;
   glm_project_zo(pos.raw, m.raw, vp.raw, dest.raw);
   return dest;
@@ -88,7 +90,7 @@ glms_project_zo(vec3s pos, mat4s m, vec4s vp, vec3 dest) {
  * @returns projected z coordinate
  */
 CGLM_INLINE
-vec3s
+float
 glms_project_z_zo(vec3s v, mat4s m) {
   return glm_project_z_zo(v.raw, m.raw);
 }

--- a/include/cglm/struct/clipspace/view_lh_no.h
+++ b/include/cglm/struct/clipspace/view_lh_no.h
@@ -19,6 +19,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/view_lh_no.h"
 
 /*!
  * @brief set up view matrix

--- a/include/cglm/struct/clipspace/view_lh_zo.h
+++ b/include/cglm/struct/clipspace/view_lh_zo.h
@@ -19,6 +19,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/view_lh_zo.h"
 
 /*!
  * @brief set up view matrix

--- a/include/cglm/struct/clipspace/view_rh_no.h
+++ b/include/cglm/struct/clipspace/view_rh_no.h
@@ -19,6 +19,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/view_rh_no.h"
 
 /*!
  * @brief set up view matrix

--- a/include/cglm/struct/clipspace/view_rh_zo.h
+++ b/include/cglm/struct/clipspace/view_rh_zo.h
@@ -19,6 +19,7 @@
 #include "../../types-struct.h"
 #include "../../plane.h"
 #include "../../cam.h"
+#include "../../clipspace/view_rh_zo.h"
 
 /*!
  * @brief set up view matrix


### PR DESCRIPTION
Add missing includes, fix signatures. Fixes #366.

`vec3.h` is required in ortho headers for `glms_vec3_unpack`.