### PR TITLE
win32, simd: ensure we are on msvc when checking MSVC specific headers

### DIFF
--- a/include/cglm/simd/intrin.h
+++ b/include/cglm/simd/intrin.h
@@ -63,7 +63,7 @@
 #endif
 
 /* ARM Neon */
-#if defined(_WIN32)
+#if defined(_WIN32) && defined(_MSC_VER)
 /* TODO: non-ARM stuff already inported, will this be better option */
 /* #  include <intrin.h> */
 

--- a/test/include/common.h
+++ b/test/include/common.h
@@ -145,7 +145,7 @@ typedef struct test_entry_t {
     } \
   } while(0);
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__) 
 # define drand48()  ((float)(rand() / (RAND_MAX + 1.0)))
 # define OK_TEXT    "ok:"
 # define FAIL_TEXT  "fail:"


### PR DESCRIPTION
should fix:

```
C:/msys64/clangarm64/lib/clang/17/include/arm64intr.h:12:15: fatal error: 'arm64intr.h' file not
      found
   12 | #include_next <arm64intr.h>
      |               ^~~~~~~~~~~~~
```

on MinGW64 aarch64. 
