### PR TITLE
ci: Remove appveyor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@
         <img src="https://github.com/recp/cglm/actions/workflows/ci.yml/badge.svg"
              alt="Build Status">
     </a>
-    <a href="https://ci.appveyor.com/project/recp/cglm/branch/master">
-        <img src="https://ci.appveyor.com/api/projects/status/av7l3gc0yhfex8y4/branch/master?svg=true"
-             alt="Windows Build Status">
-    </a>
     <a href="http://cglm.readthedocs.io/en/latest/?badge=latest">
         <img src="https://readthedocs.org/projects/cglm/badge/?version=latest"
              alt="Documentation Status">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,0 @@
-image: Visual Studio 2017
-
-build_script:
-- ps: >-
-    cd win
-
-    .\build.bat


### PR DESCRIPTION
This is now handled by the GitHub Actions CI.