### PR TITLE
aabb2d_zero, aabb2d_diagonal and aabb2d_size

### DIFF
--- a/docs/source/aabb2d.rst
+++ b/docs/source/aabb2d.rst
@@ -17,6 +17,10 @@ convert it before and after calling a cglm aabb2d function.
 Table of contents (click to go):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Macros:
+
+1. :c:func:`glm_aabb2d_size`
+
 Functions:
 
 1. :c:func:`glm_aabb2d_copy`
@@ -26,7 +30,8 @@ Functions:
 #. :c:func:`glm_aabb2d_crop_until`
 #. :c:func:`glm_aabb2d_invalidate`
 #. :c:func:`glm_aabb2d_isvalid`
-#. :c:func:`glm_aabb2d_size`
+#. :c:func:`glm_aabb2d_diag`
+#. :c:func:`glm_aabb2d_sizev`
 #. :c:func:`glm_aabb2d_radius`
 #. :c:func:`glm_aabb2d_center`
 #. :c:func:`glm_aabb2d_aabb`
@@ -111,15 +116,27 @@ Functions documentation
     Returns:
       returns true if aabb is valid otherwise false
 
-.. c:function:: float  glm_aabb2d_size(vec2 aabb[2])
+.. c:function:: float  glm_aabb2d_diag(vec2 aabb[2])
 
-    | distance between of min and max
+    | distance between min and max
 
     Parameters:
       | *[in]*   **aabb**     bounding box
 
     Returns:
       distance between min - max
+
+
+.. c:function:: void  glm_aabb2d_sizev(vec2 aabb[2], vec2 dest)
+
+    | size vector of aabb
+
+    Parameters:
+      | *[in]*   **aabb**     bounding box
+      | *[out]*  **dest**     size vector
+
+    Returns:
+      size vector of aabb max - min
 
 .. c:function:: float  glm_aabb2d_radius(vec2 aabb[2])
 

--- a/docs/source/aabb2d.rst
+++ b/docs/source/aabb2d.rst
@@ -24,6 +24,7 @@ Macros:
 Functions:
 
 1. :c:func:`glm_aabb2d_copy`
+#. :c:func:`glm_aabb2d_zero`
 #. :c:func:`glm_aabb2d_transform`
 #. :c:func:`glm_aabb2d_merge`
 #. :c:func:`glm_aabb2d_crop`
@@ -49,6 +50,13 @@ Functions documentation
     Parameters:
       | *[in]*  **aabb**  bounding box
       | *[out]* **dest**  destination
+
+.. c:function:: void  glm_aabb2d_zero(vec2 aabb[2])
+
+    | makes all members of [aabb] 0.0f (zero)
+
+    Parameters:
+      | *[in, out]*  **aabb**     bounding box
 
 .. c:function:: void  glm_aabb2d_transform(vec2 aabb[2], mat3 m, vec2 dest[2])
 

--- a/include/cglm/aabb2d.h
+++ b/include/cglm/aabb2d.h
@@ -10,8 +10,20 @@
 
 #include "common.h"
 #include "vec2.h"
-#include "vec4.h"
 #include "util.h"
+
+/*!
+ * @brief copy all members of [aabb] to [dest]
+ *
+ * @param[in]  aabb source
+ * @param[out] dest destination
+ */
+CGLM_INLINE
+void
+glm_aabb2d_zero(vec2 aabb[2]) {
+  glm_vec2_zero(aabb[0]);
+  glm_vec2_zero(aabb[1]);
+}
 
 /*!
  * @brief copy all members of [aabb] to [dest]
@@ -152,8 +164,19 @@ glm_aabb2d_isvalid(vec2 aabb[2]) {
  */
 CGLM_INLINE
 float
-glm_aabb2d_size(vec2 aabb[2]) {
+glm_aabb2d_diagonal(vec2 aabb[2]) {
   return glm_vec2_distance(aabb[0], aabb[1]);
+}
+
+/*!
+ * @brief distance between of min and max
+ *
+ * @param[in]  aabb bounding aabb
+ */
+CGLM_INLINE
+void
+glm_aabb2d_size(vec2 aabb[2], vec2 dest) {
+  glm_vec2_sub(aabb[1], aabb[0], dest); 
 }
 
 /*!
@@ -164,7 +187,7 @@ glm_aabb2d_size(vec2 aabb[2]) {
 CGLM_INLINE
 float
 glm_aabb2d_radius(vec2 aabb[2]) {
-  return glm_aabb2d_size(aabb) * 0.5f;
+  return glm_aabb2d_diagonal(aabb) * 0.5f;
 }
 
 /*!

--- a/include/cglm/aabb2d.h
+++ b/include/cglm/aabb2d.h
@@ -16,10 +16,9 @@
 #define glm_aabb2d_size(aabb)         glm_aabb2d_diag(aabb)
 
 /*!
- * @brief copy all members of [aabb] to [dest]
+ * @brief make [aabb] zero
  *
- * @param[in]  aabb source
- * @param[out] dest destination
+ * @param[in, out]  aabb
  */
 CGLM_INLINE
 void

--- a/include/cglm/aabb2d.h
+++ b/include/cglm/aabb2d.h
@@ -169,9 +169,10 @@ glm_aabb2d_diagonal(vec2 aabb[2]) {
 }
 
 /*!
- * @brief distance between of min and max
+ * @brief size of aabb
  *
  * @param[in]  aabb bounding aabb
+ * @param[out]  dest size
  */
 CGLM_INLINE
 void

--- a/include/cglm/aabb2d.h
+++ b/include/cglm/aabb2d.h
@@ -12,6 +12,9 @@
 #include "vec2.h"
 #include "util.h"
 
+/* DEPRECATED! use _diag */
+#define glm_aabb2d_size(aabb)         glm_aabb2d_diag(aabb)
+
 /*!
  * @brief copy all members of [aabb] to [dest]
  *
@@ -164,7 +167,7 @@ glm_aabb2d_isvalid(vec2 aabb[2]) {
  */
 CGLM_INLINE
 float
-glm_aabb2d_diagonal(vec2 aabb[2]) {
+glm_aabb2d_diag(vec2 aabb[2]) {
   return glm_vec2_distance(aabb[0], aabb[1]);
 }
 
@@ -176,7 +179,7 @@ glm_aabb2d_diagonal(vec2 aabb[2]) {
  */
 CGLM_INLINE
 void
-glm_aabb2d_size(vec2 aabb[2], vec2 dest) {
+glm_aabb2d_sizev(vec2 aabb[2], vec2 dest) {
   glm_vec2_sub(aabb[1], aabb[0], dest); 
 }
 
@@ -188,7 +191,7 @@ glm_aabb2d_size(vec2 aabb[2], vec2 dest) {
 CGLM_INLINE
 float
 glm_aabb2d_radius(vec2 aabb[2]) {
-  return glm_aabb2d_diagonal(aabb) * 0.5f;
+  return glm_aabb2d_diag(aabb) * 0.5f;
 }
 
 /*!

--- a/include/cglm/call/aabb2d.h
+++ b/include/cglm/call/aabb2d.h
@@ -15,6 +15,10 @@ extern "C" {
 
 CGLM_EXPORT
 void
+glmc_aabb2d_zero(vec2 aabb[2]);
+
+CGLM_EXPORT
+void
 glmc_aabb2d_copy(vec2 aabb[2], vec2 dest[2]);
 
 CGLM_EXPORT

--- a/include/cglm/call/aabb2d.h
+++ b/include/cglm/call/aabb2d.h
@@ -50,7 +50,11 @@ glmc_aabb2d_isvalid(vec2 aabb[2]);
 
 CGLM_EXPORT
 float
-glmc_aabb2d_size(vec2 aabb[2]);
+glmc_aabb2d_diagonal(vec2 aabb[2]);
+
+CGLM_EXPORT
+void
+glmc_aabb2d_size(vec2 aabb[2], vec2 dest);
 
 CGLM_EXPORT
 float

--- a/include/cglm/call/aabb2d.h
+++ b/include/cglm/call/aabb2d.h
@@ -50,11 +50,11 @@ glmc_aabb2d_isvalid(vec2 aabb[2]);
 
 CGLM_EXPORT
 float
-glmc_aabb2d_diagonal(vec2 aabb[2]);
+glmc_aabb2d_diag(vec2 aabb[2]);
 
 CGLM_EXPORT
 void
-glmc_aabb2d_size(vec2 aabb[2], vec2 dest);
+glmc_aabb2d_sizev(vec2 aabb[2], vec2 dest);
 
 CGLM_EXPORT
 float

--- a/src/aabb2d.c
+++ b/src/aabb2d.c
@@ -8,6 +8,9 @@
 #include "../include/cglm/cglm.h"
 #include "../include/cglm/call.h"
 
+/* DEPRECATED! use _diag */
+#define glmc_aabb2d_size(aabb)         glmc_aabb2d_diag(aabb)
+
 CGLM_EXPORT
 void
 glmc_aabb2d_copy(vec2 aabb[2], vec2 dest[2]) {

--- a/src/aabb2d.c
+++ b/src/aabb2d.c
@@ -13,6 +13,12 @@
 
 CGLM_EXPORT
 void
+glmc_aabb2d_zero(vec2 aabb[2]) {
+  glm_aabb2d_zero(aabb);
+}
+
+CGLM_EXPORT
+void
 glmc_aabb2d_copy(vec2 aabb[2], vec2 dest[2]) {
   glm_aabb2d_copy(aabb, dest);
 }

--- a/src/aabb2d.c
+++ b/src/aabb2d.c
@@ -55,8 +55,14 @@ glmc_aabb2d_isvalid(vec2 aabb[2]) {
 
 CGLM_EXPORT
 float
-glmc_aabb2d_size(vec2 aabb[2]) {
-  return glm_aabb2d_size(aabb);
+glmc_aabb2d_diagonal(vec2 aabb[2]) {
+  return glm_aabb2d_diagonal(aabb);
+}
+
+CGLM_EXPORT
+void
+glmc_aabb2d_size(vec2 aabb[2], vec2 dest) {
+  return glm_aabb2d_size(aabb, dest);
 }
 
 CGLM_EXPORT

--- a/src/aabb2d.c
+++ b/src/aabb2d.c
@@ -55,14 +55,14 @@ glmc_aabb2d_isvalid(vec2 aabb[2]) {
 
 CGLM_EXPORT
 float
-glmc_aabb2d_diagonal(vec2 aabb[2]) {
-  return glm_aabb2d_diagonal(aabb);
+glmc_aabb2d_diag(vec2 aabb[2]) {
+  return glm_aabb2d_diag(aabb);
 }
 
 CGLM_EXPORT
 void
-glmc_aabb2d_size(vec2 aabb[2], vec2 dest) {
-  return glm_aabb2d_size(aabb, dest);
+glmc_aabb2d_sizev(vec2 aabb[2], vec2 dest) {
+  glm_aabb2d_sizev(aabb, dest);
 }
 
 CGLM_EXPORT


### PR DESCRIPTION
-  adds `_aabb2d_zero`.

### Problem

Currently `aabb2d_size` returns `vec2_distance(min, max)`, which would be the diagonal of the aabb, if you want to use the size to resolve collisions, you need to work backwards from what aabb2d_size does when it calls vec2_distance. 

### Solution

- renames `_size` -> `_diag`. And provides a macro for compatibility
- adds a `_sizev` function which outputs a vec2, which is basically glm_vec2_sub(max, min, out).

![image](https://github.com/recp/cglm/assets/26150581/56887772-cd6b-49e6-9349-70e83363c168)

Looking for feedback if this is desirable, maybe come up with another name to avoid a breaking change on _size?