### PR TITLE
Struct API glms_ray_at incorrect dir param.

### DIFF
--- a/include/cglm/struct/ray.h
+++ b/include/cglm/struct/ray.h
@@ -75,7 +75,7 @@ CGLM_INLINE
 vec3s
 glms_ray_(at)(vec3s orig, vec3s dir, float t) {
   vec3s r;
-  glm_ray_at(orig.raw, orig.raw, t, r.raw);
+  glm_ray_at(orig.raw, dir.raw, t, r.raw);
   return r;
 }
 


### PR DESCRIPTION
Fixes what appears to me like an accidental copy-paste mistake with the `dir` parameter of the struct API for `glms_ray_at()`.
Introduced in https://github.com/recp/cglm/commit/73a4fc76d7a91d65ab4619e20a6833b0111fd402 (v0.9.3), discovered during compilation by Clang warnings.

```
[build] ***/vendor/cglm/include/cglm/struct/ray.h:76:33: warning: unused parameter 'dir' [-Wunused-parameter]
[build] glms_ray_(at)(vec3s orig, vec3s dir, float t) {
[build]                                 ^
[build] 1 warning generated.
```