### PR TITLE
docs: expand wy-nav-content width to edge of screen

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,6 +91,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+pygments_style = 'monokai'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -111,8 +112,11 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['sphinx-static']
 
+# Add customm CSS and JS files
+html_css_files = ['theme_overrides.css']
+html_js_files = []
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/docs/source/sphinx-static/theme_overrides.css
+++ b/docs/source/sphinx-static/theme_overrides.css
@@ -1,0 +1,12 @@
+@media screen {
+  /* content column
+   *
+   * RTD theme's default is 800px as max width for the content, but we have
+   * tables with tons of columns, which need the full width of the view-port.
+   *
+   * Comment from yocto project theme_overrides.css
+   */
+
+  .wy-nav-content{ max-width: none; }
+
+}


### PR DESCRIPTION
RTD theme's default is 800px as max width for the content, but we have tables with tons of columns, which need the full width of the view-port.

Comment from yocto project theme_overrides.css