### PR TITLE
Fixed 'missing-prototypes' warnings for some vec2 funcs.

### DIFF
--- a/include/cglm/call/vec2.h
+++ b/include/cglm/call/vec2.h
@@ -19,6 +19,18 @@ glmc_vec2(float * __restrict v, vec2 dest);
 
 CGLM_EXPORT
 void
+glmc_vec2_fill(vec2 v, float val);
+
+CGLM_EXPORT
+bool
+glmc_vec2_eq(vec2 v, float val);
+
+CGLM_EXPORT
+bool
+glmc_vec2_eqv(vec2 a, vec2 b);
+
+CGLM_EXPORT
+void
 glmc_vec2_copy(vec2 a, vec2 dest);
 
 CGLM_EXPORT


### PR DESCRIPTION
Using gcc and missing-prototypes flag shows warnings for: glmc_vec2_fill, glmc_vec2_eq and glmc_vec2_eqv. 
Seems they were not added to call/vec2.h for some reason. This should fix the warnings.