### PR TITLE
Bump CMake minimum version to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13)
 project(cglm
   VERSION 0.9.5
   HOMEPAGE_URL https://github.com/recp/cglm
@@ -37,9 +37,10 @@ if(MSVC)
   if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
     add_definitions(-DNDEBUG)
     add_compile_options(/W3 /Ox /Gy /Oi /TC)
+
     foreach(flag_var
-        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+      CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+      CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
       string(REGEX REPLACE "/RTC(su|[1su])" "" ${flag_var} "${${flag_var}}")
     endforeach(flag_var)
   endif()
@@ -56,6 +57,7 @@ get_directory_property(hasParent PARENT_DIRECTORY)
 if(NOT hasParent AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
   set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
+
   # Set the possible values of build type for cmake-gui
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
@@ -116,7 +118,7 @@ add_library(${PROJECT_NAME}
   src/clipspace/view_rh_zo.c
   src/clipspace/project_no.c
   src/clipspace/project_zo.c
-  )
+)
 
 if(CGLM_SHARED)
   add_definitions(-DCGLM_EXPORTS)
@@ -125,8 +127,8 @@ else()
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
-                              VERSION ${PROJECT_VERSION} 
-                            SOVERSION ${PROJECT_VERSION_MAJOR})
+  VERSION ${PROJECT_VERSION}
+  SOVERSION ${PROJECT_VERSION_MAJOR})
 
 if(WIN32)
   # Because SOVERSION has no effect to file naming on Windows
@@ -135,11 +137,11 @@ if(WIN32)
 endif()
 
 target_include_directories(${PROJECT_NAME}
-    PUBLIC 
-        $<INSTALL_INTERFACE:include>    
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
+  PUBLIC
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 # Target for header-only usage
@@ -154,40 +156,43 @@ if(CGLM_USE_TEST)
   add_subdirectory(test)
 endif()
 
-# Install 
+# Install
 install(TARGETS ${PROJECT_NAME}
-        EXPORT  ${PROJECT_NAME}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  EXPORT ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        PATTERN ".*" EXCLUDE)
+  PATTERN ".*" EXCLUDE)
 
 # Config
 export(TARGETS ${PROJECT_NAME}
-       NAMESPACE ${PROJECT_NAME}::
-       FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  NAMESPACE ${PROJECT_NAME}::
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
 )
 
-install(EXPORT      ${PROJECT_NAME}
-        FILE        "${PROJECT_NAME}Config.cmake"
-        NAMESPACE   ${PROJECT_NAME}::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+install(EXPORT ${PROJECT_NAME}
+  FILE "${PROJECT_NAME}Config.cmake"
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 set(PACKAGE_NAME ${PROJECT_NAME})
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix ${CMAKE_INSTALL_PREFIX})
-if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
   set(includedir "${CMAKE_INSTALL_INCLUDEDIR}")
 else()
   set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 endif()
-if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
   set(libdir "${CMAKE_INSTALL_LIBDIR}")
 else()
   set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
 endif()
+
 set(PACKAGE_VERSION "${PROJECT_VERSION}")
 configure_file(cglm.pc.in cglm.pc @ONLY)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,9 @@ if(MSVC)
   if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
     add_definitions(-DNDEBUG)
     add_compile_options(/W3 /Ox /Gy /Oi /TC)
-
     foreach(flag_var
-      CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-      CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
       string(REGEX REPLACE "/RTC(su|[1su])" "" ${flag_var} "${${flag_var}}")
     endforeach(flag_var)
   endif()
@@ -57,7 +56,6 @@ get_directory_property(hasParent PARENT_DIRECTORY)
 if(NOT hasParent AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
   set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
-
   # Set the possible values of build type for cmake-gui
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
@@ -118,7 +116,7 @@ add_library(${PROJECT_NAME}
   src/clipspace/view_rh_zo.c
   src/clipspace/project_no.c
   src/clipspace/project_zo.c
-)
+  )
 
 if(CGLM_SHARED)
   add_definitions(-DCGLM_EXPORTS)
@@ -127,8 +125,8 @@ else()
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
-  VERSION ${PROJECT_VERSION}
-  SOVERSION ${PROJECT_VERSION_MAJOR})
+                              VERSION ${PROJECT_VERSION} 
+                            SOVERSION ${PROJECT_VERSION_MAJOR})
 
 if(WIN32)
   # Because SOVERSION has no effect to file naming on Windows
@@ -137,11 +135,11 @@ if(WIN32)
 endif()
 
 target_include_directories(${PROJECT_NAME}
-  PUBLIC
-  $<INSTALL_INTERFACE:include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/src
+    PUBLIC 
+        $<INSTALL_INTERFACE:include>    
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 # Target for header-only usage
@@ -156,43 +154,40 @@ if(CGLM_USE_TEST)
   add_subdirectory(test)
 endif()
 
-# Install
+# Install 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+        EXPORT  ${PROJECT_NAME}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  PATTERN ".*" EXCLUDE)
+        PATTERN ".*" EXCLUDE)
 
 # Config
 export(TARGETS ${PROJECT_NAME}
-  NAMESPACE ${PROJECT_NAME}::
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+       NAMESPACE ${PROJECT_NAME}::
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
 )
 
-install(EXPORT ${PROJECT_NAME}
-  FILE "${PROJECT_NAME}Config.cmake"
-  NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+install(EXPORT      ${PROJECT_NAME}
+        FILE        "${PROJECT_NAME}Config.cmake"
+        NAMESPACE   ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 set(PACKAGE_NAME ${PROJECT_NAME})
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix ${CMAKE_INSTALL_PREFIX})
-
-if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
   set(includedir "${CMAKE_INSTALL_INCLUDEDIR}")
 else()
   set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 endif()
-
-if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
   set(libdir "${CMAKE_INSTALL_LIBDIR}")
 else()
   set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
 endif()
-
 set(PACKAGE_VERSION "${PROJECT_VERSION}")
 configure_file(cglm.pc.in cglm.pc @ONLY)
 


### PR DESCRIPTION
## What

This bumps the minimum CMake version from `3.8.2` to `3.13.0`.

## Goal

Hiding this warning message:

```
Not searching for unused variables given on the command line.
[cmake] CMake Warning (dev) at vendor/cglm/CMakeLists.txt:15 (option):
[cmake]   Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
[cmake]   --help-policy CMP0077" for policy details.  Use the cmake_policy command to
[cmake]   set the policy and suppress this warning.
[cmake] 
[cmake]   For compatibility with older versions of CMake, option is clearing the
[cmake]   normal variable 'CGLM_STATIC'.
[cmake] This warning is for project developers.  Use -Wno-dev to suppress it.
[cmake] 
```

## Why

Different versions of CMake comes with different policies enabled by default.

As of 3.13.0, CMake introduced the policy [CMP0077](https://cmake.org/cmake/help/latest/policy/CMP0077.html) which, because this project is on an older version, wants users vendoring `cglm` to specify whether they prefer the `OLD` or `NEW` behavior, resulting in either `set(CMAKE_POLICY_DEFAULT_CMP0077 X)` before `add_subdirectory(vendor/cglm)` or `cmake_policy(CMP0077 X)` for the whole project.

## Explanation

The `NEW` behavior (that version 3.13.0 introduced) is sane and desirable for everybody.

Prior, `option()` was copying identically named variables into the cache and then ignoring any future mutations unless re-configuring the whole project. Now, `option()` prefers to do nothing, not even caching, essentially honoring at all times what the early variable definition requested (that option() would've normally set).

This allows for users to properly configure CGML's options even though it's a subdirectory and to not worry about possible overrides or left over cache headaches.

e.g.

```
option(CGLM_STATIC "Static build" ON)
add_subdirectory(vendor/cglm)
target_add_library(example PRIVATE cglm)
```

## Backwards compatibility

* Users that explicitly want to keep the old behavior would've already needed the policy line and the version upgrade wont distrupt their choice. That's the whole point of configurable CMake policies.

* Everybody else on newer CMake versions that didn't pick a policy accidently rely on the new behavior and therefore not impacted by the new version because the default maintains that behavior.

## Notes

It seems 3.8.2 was in 2017 and 3.13.0 in 2018. Both are old enough that probably everyone and all the major distros are well beyond. Personally, I use MinGW a lot and am on 3.26.4, while officially the latest is 3.30.3.