### PR TITLE
Fix numbering - opengl matrix uniform examples (docs)

### DIFF
--- a/docs/source/opengl.rst
+++ b/docs/source/opengl.rst
@@ -34,7 +34,7 @@ array of matrices:
    /* ... */
    glUniformMatrix4fv(location, count, GL_FALSE, matrix[0][0]);
 
-1. Cast matrix to pointer
+2. Cast matrix to pointer
 --------------------------
 
 .. code-block:: c


### PR DESCRIPTION
I was just reading the docs and noticed this, I think this should be numbered 2? Above is an alternative approach already numbered 1.