### PR TITLE
Typo

### DIFF
--- a/docs/source/mat4.rst
+++ b/docs/source/mat4.rst
@@ -143,7 +143,7 @@ Functions documentation
 
     .. code-block:: c
 
-       mat m1, m2, m3, m4, res;
+       mat4 m1, m2, m3, m4, res;
        glm_mat4_mulN((mat4 *[]){&m1, &m2, &m3, &m4}, 4, res);
 
     Parameters:

--- a/include/cglm/mat4.h
+++ b/include/cglm/mat4.h
@@ -360,7 +360,7 @@ glm_mat4_mul(mat4 m1, mat4 m2, mat4 dest) {
  * size but if <b>len</b> is too small then compiler may unroll whole loop,
  * usage:
  * @code
- * mat m1, m2, m3, m4, res;
+ * mat4 m1, m2, m3, m4, res;
  *
  * glm_mat4_mulN((mat4 *[]){&m1, &m2, &m3, &m4}, 4, res);
  * @endcode

--- a/include/cglm/struct/mat4.h
+++ b/include/cglm/struct/mat4.h
@@ -223,7 +223,7 @@ glms_mat4_(mul)(mat4s m1, mat4s m2) {
  * size but if <b>len</b> is too small then compiler may unroll whole loop,
  * usage:
  * @code
- * mat m1, m2, m3, m4, res;
+ * mat4 m1, m2, m3, m4, res;
  *
  * res = glm_mat4_mulN((mat4 *[]){&m1, &m2, &m3, &m4}, 4);
  * @endcode


### PR DESCRIPTION
Should be `mat4` in code block docs for `mat4_mulN`.