### PR TITLE
integration utilities

### DIFF
--- a/include/cglm/applesimd.h
+++ b/include/cglm/applesimd.h
@@ -14,16 +14,17 @@
     && defined(SIMD_VECTOR_TYPES)
 
 #include "common.h"
+#include "struct.h"
 
 /*!
-* @brief converts mat4 to Apple's simd type simd_float4x4
-* @return simd_float4x4
-*/
+ * @brief converts mat4 to Apple's simd type simd_float4x4
+ * @return simd_float4x4
+ */
 CGLM_INLINE
 simd_float4x4
 glm_mat4_applesimd(mat4 m) {
   simd_float4x4 t;
-  
+
   t.columns[0][0] = m[0][0];
   t.columns[0][1] = m[0][1];
   t.columns[0][2] = m[0][2];
@@ -55,7 +56,7 @@ CGLM_INLINE
 simd_float3x3
 glm_mat3_applesimd(mat3 m) {
   simd_float3x3 t;
-  
+
   t.columns[0][0] = m[0][0];
   t.columns[0][1] = m[0][1];
   t.columns[0][2] = m[0][2];
@@ -83,13 +84,53 @@ glm_vec4_applesimd(vec4 v) {
 
 /*!
 * @brief converts vec3 to Apple's simd type simd_float3
-* @return v
+* @return simd_float3
 */
 CGLM_INLINE
 simd_float3
 glm_vec3_applesimd(vec3 v) {
   return (simd_float3){v[0], v[1], v[2]};
 }
+
+/*!
+ * @brief generic function to convert cglm types to Apple's simd types
+ *
+ * Example usage:
+ *   simd_float4x4 m = applesimd(mat4_value);
+ *   simd_float3   v = applesimd(vec3_value);
+ *
+ * @param x cglm type (mat4, mat3, vec4, vec3)
+ * @return corresponding Apple simd type
+ */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#  define applesimd(x) _Generic((x),                    \
+                         mat4:  glm_mat4_applesimd,     \
+                         mat3:  glm_mat3_applesimd,     \
+                         vec4:  glm_vec4_applesimd,     \
+                         vec3:  glm_vec3_applesimd      \
+                       )((x))
+#endif
+
+#ifdef cglm_types_struct_h
+CGLM_INLINE simd_float4x4 glms_mat4_(applesimd)(mat4s m) { return glm_mat4_applesimd(m.raw); }
+CGLM_INLINE simd_float3x3 glms_mat3_(applesimd)(mat3s m) { return glm_mat3_applesimd(m.raw); }
+CGLM_INLINE simd_float4   glms_vec4_(applesimd)(vec4s v) { return glm_vec4_applesimd(v.raw); }
+CGLM_INLINE simd_float3   glms_vec3_(applesimd)(vec3s v) { return glm_vec3_applesimd(v.raw); }
+
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#  undef applesimd
+#  define applesimd(x) _Generic((x),                       \
+                         mat4:  glm_mat4_applesimd,        \
+                         mat3:  glm_mat3_applesimd,        \
+                         vec4:  glm_vec4_applesimd,        \
+                         vec3:  glm_vec3_applesimd,        \
+                         mat4s: glms_mat4_(applesimd),     \
+                         mat3s: glms_mat3_(applesimd),     \
+                         vec4s: glms_vec4_(applesimd),     \
+                         vec3s: glms_vec3_(applesimd)      \
+                       )((x))
+#endif
+#endif
 
 #endif
 #endif /* cglm_applesimd_h */

--- a/include/cglm/common.h
+++ b/include/cglm/common.h
@@ -8,6 +8,8 @@
 #ifndef cglm_common_h
 #define cglm_common_h
 
+#define __cglm__ 1
+
 #ifndef _USE_MATH_DEFINES
 #  define _USE_MATH_DEFINES       /* for windows */
 #endif


### PR DESCRIPTION
* define `__cglm__` to publish cglm availability universally instead of checking arbitrary header like `cglm_common_h` which may be changed at any time
* some apple simd framework integration helpers

use-cases:

I'm trying to finish (just got back to) http://github.com/recp/AssetKit which is waiting in in-progress long time. **cglm** is optional in public headers but I want to give some helpers if **cglm** is used in target like:

```C
#ifdef __cglm__
AK_INLINE
void
ak_someHelper() {
    ...
}
#endif
```



