### PR TITLE
Fix `make` on `srcdir != builddir`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ checkCFLAGS = $(AM_CFLAGS) \
                -std=gnu11 \
                -O3 \
                -DCGLM_DEFINE_PRINTS \
-               -I./include
+               -I$(srcdir)/include
 
 check_PROGRAMS = test/tests
 TESTS = $(check_PROGRAMS)


### PR DESCRIPTION
The make check command fails because the include path is not appropriate for the Makefile generated by autotools when the source and build directories are different.

```
$ cd /tmp
$ git clone https://github.com/recp/cglm.git
$ cd cglm
$ autoreconf -fiv
$ mkdir build
$ cd build
$ ../configure
:
$ make check
:
/Library/Developer/CommandLineTools/usr/bin/make  test/tests
  CC       test/tests-runner.o
In file included from ../test/runner.c:8:
../test/include/common.h:31:10: fatal error: 'cglm/cglm.h' file not found
   31 | #include <cglm/cglm.h>
      |          ^~~~~~~~~~~~~
1 error generated.
make[1]: *** [test/tests-runner.o] Error 1
make: *** [check-am] Error 2
```