### PR TITLE
Add missing glmc_perspective_resize_**_**() call/clipspace functions

### DIFF
--- a/include/cglm/call/clipspace/persp_lh_no.h
+++ b/include/cglm/call/clipspace/persp_lh_no.h
@@ -27,6 +27,10 @@ glmc_perspective_lh_no(float fovy,
                        float nearVal,
                        float farVal,
                        mat4 dest);
+                       
+CGLM_EXPORT
+void
+glmc_perspective_resize_lh_no(float aspect, mat4 proj);
 
 CGLM_EXPORT
 void

--- a/include/cglm/call/clipspace/persp_lh_zo.h
+++ b/include/cglm/call/clipspace/persp_lh_zo.h
@@ -27,6 +27,10 @@ glmc_perspective_lh_zo(float fovy,
                        float nearVal,
                        float farVal,
                        mat4 dest);
+                       
+CGLM_EXPORT
+void
+glmc_perspective_resize_lh_zo(float aspect, mat4 proj);
 
 CGLM_EXPORT
 void

--- a/include/cglm/call/clipspace/persp_rh_no.h
+++ b/include/cglm/call/clipspace/persp_rh_no.h
@@ -27,6 +27,10 @@ glmc_perspective_rh_no(float fovy,
                        float nearVal,
                        float farVal,
                        mat4 dest);
+                       
+CGLM_EXPORT
+void
+glmc_perspective_resize_rh_no(float aspect, mat4 proj);
 
 CGLM_EXPORT
 void

--- a/include/cglm/call/clipspace/persp_rh_zo.h
+++ b/include/cglm/call/clipspace/persp_rh_zo.h
@@ -27,6 +27,10 @@ glmc_perspective_rh_zo(float fovy,
                        float nearVal,
                        float farVal,
                        mat4 dest);
+                       
+CGLM_EXPORT
+void
+glmc_perspective_resize_rh_zo(float aspect, mat4 proj);
 
 CGLM_EXPORT
 void

--- a/src/clipspace/persp_lh_no.c
+++ b/src/clipspace/persp_lh_no.c
@@ -36,6 +36,12 @@ glmc_perspective_lh_no(float fovy,
 
 CGLM_EXPORT
 void
+glmc_perspective_resize_lh_no(float aspect, mat4 proj) {
+  glm_perspective_resize_lh_no(aspect, proj);
+}
+
+CGLM_EXPORT
+void
 glmc_persp_move_far_lh_no(mat4 proj, float deltaFar) {
   glm_persp_move_far_lh_no(proj, deltaFar);
 }

--- a/src/clipspace/persp_lh_zo.c
+++ b/src/clipspace/persp_lh_zo.c
@@ -36,6 +36,12 @@ glmc_perspective_lh_zo(float fovy,
 
 CGLM_EXPORT
 void
+glmc_perspective_resize_lh_zo(float aspect, mat4 proj) {
+  glm_perspective_resize_lh_zo(aspect, proj);
+}
+
+CGLM_EXPORT
+void
 glmc_persp_move_far_lh_zo(mat4 proj, float deltaFar) {
   glm_persp_move_far_lh_zo(proj, deltaFar);
 }

--- a/src/clipspace/persp_rh_no.c
+++ b/src/clipspace/persp_rh_no.c
@@ -36,6 +36,12 @@ glmc_perspective_rh_no(float fovy,
 
 CGLM_EXPORT
 void
+glmc_perspective_resize_rh_no(float aspect, mat4 proj) {
+  glm_perspective_resize_rh_no(aspect, proj);
+}
+
+CGLM_EXPORT
+void
 glmc_persp_move_far_rh_no(mat4 proj, float deltaFar) {
   glm_persp_move_far_rh_no(proj, deltaFar);
 }

--- a/src/clipspace/persp_rh_zo.c
+++ b/src/clipspace/persp_rh_zo.c
@@ -36,6 +36,12 @@ glmc_perspective_rh_zo(float fovy,
 
 CGLM_EXPORT
 void
+glmc_perspective_resize_rh_zo(float aspect, mat4 proj) {
+  glm_perspective_resize_rh_zo(aspect, proj);
+}
+
+CGLM_EXPORT
+void
 glmc_persp_move_far_rh_zo(mat4 proj, float deltaFar) {
   glm_persp_move_far_rh_zo(proj, deltaFar);
 }


### PR DESCRIPTION
Added missing perspective resize clipspace functions to Call API, fixing the issue #481 