### PR TITLE
box/aabb2d: fix wrong face selected below AABB min bound in sphere/circle test

### DIFF
--- a/include/cglm/aabb2d.h
+++ b/include/cglm/aabb2d.h
@@ -235,8 +235,8 @@ glm_aabb2d_circle(vec2 aabb[2], vec3 c) {
   a = (c[0] < aabb[0][0]) + (c[0] > aabb[1][0]);
   b = (c[1] < aabb[0][1]) + (c[1] > aabb[1][1]);
 
-  dmin  = glm_pow2((c[0] - aabb[!(a - 1)][0]) * (a != 0))
-        + glm_pow2((c[1] - aabb[!(b - 1)][1]) * (b != 0));
+  dmin  = glm_pow2((c[0] - aabb[c[0] > aabb[1][0]][0]) * (a != 0))
+        + glm_pow2((c[1] - aabb[c[1] > aabb[1][1]][1]) * (b != 0));
 
   return dmin <= glm_pow2(c[2]);
 }

--- a/include/cglm/box.h
+++ b/include/cglm/box.h
@@ -243,9 +243,9 @@ glm_aabb_sphere(vec3 box[2], vec4 s) {
   b = (s[1] < box[0][1]) + (s[1] > box[1][1]);
   c = (s[2] < box[0][2]) + (s[2] > box[1][2]);
 
-  dmin  = glm_pow2((s[0] - box[!(a - 1)][0]) * (a != 0))
-        + glm_pow2((s[1] - box[!(b - 1)][1]) * (b != 0))
-        + glm_pow2((s[2] - box[!(c - 1)][2]) * (c != 0));
+  dmin  = glm_pow2((s[0] - box[s[0] > box[1][0]][0]) * (a != 0))
+        + glm_pow2((s[1] - box[s[1] > box[1][1]][1]) * (b != 0))
+        + glm_pow2((s[2] - box[s[2] > box[1][2]][2]) * (c != 0));
 
   return dmin <= glm_pow2(s[3]);
 }


### PR DESCRIPTION
## Problem

`glm_aabb_sphere()` (include/cglm/box.h) and `glm_aabb2d_circle()` (include/cglm/aabb2d.h) compute the closest point on an AABB to a sphere/circle center per axis using:

```c
a = (s[i] < box[0][i]) + (s[i] > box[1][i]);
...
box[!(a - 1)][i]
```

`a` is `1` for *either* out-of-range direction (below `box[0]` or above `box[1]`), and `!(a - 1)` collapses to index `1` (the max face) whenever `a == 1`, regardless of which side the point is actually on. So when the query point is below the box's min bound on an axis, the code clamps to the **max** face instead of the **min** face, producing an incorrect (too-large) distance-squared contribution and false-negative intersection results.

## Fix

Use the already-computed "above max" boolean directly as the face index instead of the `!(a - 1)` derivation:

```c
box[s[i] > box[1][i]][i]
```

This selects `box[0]` (min face) when the point is below the min bound and `box[1]` (max face) when above the max bound. The in-range case is unaffected — it's already zeroed out by the existing `(a != 0)` multiplier, so the index value there doesn't matter.

Same one-line-per-axis change applied identically to both `glm_aabb_sphere` (3 axes) and `glm_aabb2d_circle` (2 axes), since they share the exact same root cause.

## Verification

- Manual cases: sphere/circle center below `box[0]` on one axis, below on two axes simultaneously (3D), etc. — all mismatched (false negative) before the fix, correct after.
- Randomized fuzz test, 200,000 cases with random box bounds / sphere center / radius, checked against a hand-written point-to-AABB squared-distance reference: 3418/200000 (1.7%) false negatives before the fix, 0/200000 after.
- Full `cglm.h` still compiles clean with `-Wall -Wextra`.

Diff is minimal: 2 files, 5 insertions / 5 deletions, no behavior change to the in-range or above-max cases.
